### PR TITLE
Python WebSocket bug

### DIFF
--- a/examples/binary/client.py
+++ b/examples/binary/client.py
@@ -1,0 +1,7 @@
+from binary import BinaryClient
+from builtin.concurrent import Context
+
+runtime = Context.runtime()
+
+client = BinaryClient(runtime, "ws://127.0.0.1:8910/binary")
+

--- a/quarkc/builtin/quark_runtime.py
+++ b/quarkc/builtin/quark_runtime.py
@@ -321,7 +321,7 @@ class Buffer(object):
         if _data is None:
             _data = bytearray()
         elif not isinstance(_data, bytearray):
-            _data = bytearray(data)
+            _data = bytearray(_data)
         self.data = _data
         self.rdata = buffer(_data)
         self._order(self.BE)

--- a/quarkc/test/emit/expected/py/builtin/quark_runtime.py
+++ b/quarkc/test/emit/expected/py/builtin/quark_runtime.py
@@ -321,7 +321,7 @@ class Buffer(object):
         if _data is None:
             _data = bytearray()
         elif not isinstance(_data, bytearray):
-            _data = bytearray(data)
+            _data = bytearray(_data)
         self.data = _data
         self.rdata = buffer(_data)
         self._order(self.BE)


### PR DESCRIPTION
I decided to write JavaScript and Python clients for the binary example. The Python client crashed because there ain't no `data` variable here...