### PR TITLE
Test harness for automatically running and verifying Quark examples

### DIFF
--- a/examples/binary/test-example.sh
+++ b/examples/binary/test-example.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+echo "Starting verification of Binary example"
+
+# Prep
+failed=0  # Any failure will set this to 1
+targetdir=${0%/*} # get script's own directory
+cd $targetdir
+source ../../scripts/example-test-utils.sh
+
+# Prep
+cleanLogs
+
+# Build
+npm -s uninstall binary # spurious errors happen if we don't force this
+quark install binary.q --all
+mvn -q compile
+
+# Launch the server that all the clients will hit
+echo Launching Java server...
+mvn exec:java -Dexec.mainClass=binary.ServerMain > log/j-server.log 2>&1 &
+serverpid=$!
+sleep 5 # Give the server time to init
+
+testProcessOutput \
+  "Java binary client" \
+  "mvn exec:java -Dexec.mainClass=binary.ClientMain" \
+  5 \
+  log/j-binary.log \
+  "de ad be ef"
+
+testProcessOutput \
+  "JavaScript binary client" \
+  "node client.js" \
+  3 \
+  log/js-binary.log \
+  "de ad be ef"
+
+testProcessOutput \
+  "Python binary client" \
+  "python client.py" \
+  3 \
+  log/py-binary.log \
+  "de ad be ef"
+
+# Quietly kill the background Java service
+kill $serverpid
+wait $serverpid 2>/dev/null
+
+echo "**********************"
+if [ $failed == "1" ]
+then
+  echo Binary example: FAILED
+else
+  echo Binary example: PASSED
+fi
+echo "**********************"
+
+# Exit with status so outer scripts can interpret the
+# overall demo result
+exit $failed

--- a/examples/helloRPC/hello.q
+++ b/examples/helloRPC/hello.q
@@ -24,7 +24,7 @@ namespace hello {
 	// Number of failed requests before circuit breaker trips
         static int failureLimit = 1;
 	// How long (in seconds) before circuit breaker resets
-        static float retestDelay = 30.0;
+        static float retestDelay = 10.0;
 
         @doc("Respond to a hello request.")
         Response hello(Request request) {

--- a/examples/helloRPC/test-example.sh
+++ b/examples/helloRPC/test-example.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+echo "Starting verification of HelloRPC example"
+
+# Prep
+failed=0  # Any failure will set this to 1
+targetdir=${0%/*} # get script's own directory
+cd $targetdir
+source ../../scripts/example-test-utils.sh
+
+# Prep
+cleanLogs
+checkStaleService 8910
+
+# Build
+npm -s uninstall hello # spurious errors happen if we don't force this
+quark install hello.q --all
+mvn -q compile
+
+# Run and verify the examples
+testClientServer \
+  "Python - Python" \
+  "python -u pyserver.py" \
+  "python -u pyclient.py" \
+  2 \
+  log/py-py-s.log \
+  log/py-py-c.log \
+  "Responding to \[Hello from Python!\] from Python"
+
+testClientServer \
+  "JS - JS" \
+  "node jsserver.js" \
+  "node jsclient.js" \
+  2 \
+  log/js-js-s.log \
+  log/js-js-c.log \
+  "Response says Responding to \[Hello from JavaScript!\] from JavaScript"
+
+testClientServer \
+  "Java - Java" \
+  "mvn exec:java -Dexec.mainClass=helloRPC.HelloRPCServer" \
+  "mvn exec:java -Dexec.mainClass=helloRPC.HelloRPCClient" \
+  5 \
+  log/j-j-s.log \
+  log/j-j-c.log \
+  "Response says: Responding to \[Hello from Java!\] from Java"
+
+testClientServer \
+  "JS - Python" \
+  "python -u pyserver.py" \
+  "node jsclient.js" \
+  2 \
+  log/js-py-s.log \
+  log/js-py-c.log \
+  "Response says Responding to \[Hello from JavaScript!\] from Python"
+
+testClientServer \
+  "Java - Python" \
+  "python -u pyserver.py" \
+  "mvn exec:java -Dexec.mainClass=helloRPC.HelloRPCClient" \
+  2 \
+  log/j-py-s.log \
+  log/j-py-c.log \
+  "Response says: Responding to \[Hello from Java!\] from Python"
+
+testClientServer \
+  "Python - Java" \
+  "mvn exec:java -Dexec.mainClass=helloRPC.HelloRPCServer" \
+  "python -u pyclient.py" \
+  5 \
+  log/py-j-s.log \
+  log/py-j-c.log \
+  "Response says u'Responding to \[Hello from Python!\] from Java'"
+
+testClientServer \
+  "JS - Java" \
+  "mvn exec:java -Dexec.mainClass=helloRPC.HelloRPCServer" \
+  "node jsclient.js" \
+  5 \
+  log/js-j-s.log \
+  log/js-j-c.log \
+  "Response says Responding to \[Hello from JavaScript!\] from Java"
+
+testClientServer \
+  "Java - JS" \
+  "node jsserver.js" \
+  "mvn exec:java -Dexec.mainClass=helloRPC.HelloRPCClient" \
+  2 \
+  log/j-js-s.log \
+  log/j-js-c.log \
+  "Response says: Responding to \[Hello from Java!\] from JavaScript"
+
+testClientServer \
+  "Python - JS" \
+  "node jsserver.js" \
+  "python -u pyclient.py" \
+  2 \
+  log/py-js-s.log \
+  log/py-js-c.log \
+  "Response says u\'Responding to \[Hello from Python!\] from JavaScript\'"
+
+echo "************************"
+if [ $failed == "1" ]
+then
+  echo HelloRPC example: FAILED
+else
+  echo HelloRPC example: PASSED
+fi
+echo "************************"
+
+# Exit with status so outer scripts can interpret the
+# overall demo result
+exit $failed

--- a/examples/slack/bot.js
+++ b/examples/slack/bot.js
@@ -34,4 +34,5 @@ try {
     process.exit(1);
 }
 var client = new slack.SlackClient(token);
+client.post("#demo", "JavaScript Slack client is connected");
 client.subscribe(new Handler());

--- a/examples/slack/bot.py
+++ b/examples/slack/bot.py
@@ -31,7 +31,7 @@ def main():
         exit("Failed to read Slack token. See examples/README.md for more information.")
 
     client = slack.SlackClient(token)
-    client.post("#demo", "testing...")
+    client.post("#demo", "Python Slack client is connected")
     client.subscribe(Handler())
 
 

--- a/examples/slack/src/main/java/bot/SlackBot.java
+++ b/examples/slack/src/main/java/bot/SlackBot.java
@@ -27,6 +27,7 @@ import slack.event.UserTyping;
 public class SlackBot implements SlackHandler {
     public static void main(String[] args) throws Exception {
         SlackClient client = new SlackClient(getToken());
+        client.post("#demo", "Java Slack client is connected");
         client.subscribe(new SlackBot());
 
     }

--- a/examples/slack/test-example.sh
+++ b/examples/slack/test-example.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+echo "Starting verification of Slack example"
+
+# Prep
+failed=0  # Any failure will set this to 1
+targetdir=${0%/*} # get script's own directory
+cd $targetdir
+source ../../scripts/example-test-utils.sh
+
+# Prep
+cleanLogs
+
+# Check for the Slack token file. Without it, no point in proceeding.
+if [ ! -f .slack.token ]; then
+    echo "Slack token not found, cannot run Slack demo"
+    failed=1
+fi
+
+# Build
+npm -s uninstall slack # spurious errors happen if we don't force this
+quark install slack.q --all
+mvn -q compile
+
+testProcessOutput \
+  "Python Slack client" \
+  "python -u bot.py" \
+  3 \
+  log/py-slack.log \
+  "slack.event.SlackEvent object at"
+
+testProcessOutput \
+  "JavaScript Slack client" \
+  "node bot.js" \
+  3 \
+  log/js-slack.log \
+  "Hello {"
+
+testProcessOutput \
+  "Java Slack client" \
+  "mvn exec:java -Dexec.mainClass=bot.SlackBot" \
+  8 \
+  log/j-slack.log \
+  "WebSocket Client connected!"
+
+
+echo "*********************"
+if [ $failed == "1" ]
+then
+  echo Slack example: FAILED
+else
+  echo Slack example: PASSED
+fi
+echo "*********************"
+
+# Exit with status so outer scripts can interpret the
+# overall demo result
+exit $failed

--- a/scripts/example-test-utils.sh
+++ b/scripts/example-test-utils.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# check(
+#   $1: pattern to find, $2: file to search, $3: test description)
+check() {
+  if grep -q "$1" $2
+  then
+    echo $3"...PASS"
+  else
+    echo $3 "*** FAIL! ***"
+    echo "Did not find pattern $1 in file $2"
+    failed=1
+  fi
+}
+
+# testClientServer(
+#   $1: description, $2: server command, $3: client command,
+#   $4: sleep period, $5: server log file, $6: client log file,
+#   $7: expected pattern in client log)
+testClientServer() {
+  $2 > $5 2>&1 & # Launch server
+  sleep $4  # let server become ready
+  $3 > $6 2>&1  # launch client
+  kill $!  # signal server to die
+  wait $! 2>/dev/null # block waiting for server to die
+  sleep 1 # wait a little more before proceeding (spurious failures happen without this)
+  check "$7" $6 "$1" # check the log files for 'success' pattern
+}
+
+# testProcessOutput(
+#   $1: description, $2: process to launch, $3: sleep period,
+#   $4: log file, $5: expected pattern in log file
+testProcessOutput() {
+  $2 > $4 & # Launch process and redirect output
+  sleep $3  # let process become ready
+  kill $!  # signal process to die
+  wait $! 2>/dev/null # block waiting for process to die
+  sleep 2 # wait a little more before proceeding (spurious failures happen without this)
+  check "$5" $4 "$1" # check the log file for 'success' pattern
+}
+
+# cleanLogs() - cleans and recreates "log" directory relative to cwd
+cleanLogs() {
+  rm -rf ./log
+  mkdir ./log
+}
+
+# checkStaleService(
+#   $1: port to check)
+checkStaleService() {
+  echo Checking for a stale server...
+  nc -vz 127.0.0.1 $1 > /dev/null 2>&1
+  if [ "$?" == "1" ]
+  then
+    echo No stale server found.
+  else
+    echo "*** FAIL! *** Port $1 in use. Stale server running?"
+    failed=1
+    exit $failed # Abandon run - nothing will work if server port is in use
+  fi
+}

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Prep
+failed=0  # Any failure encountered below will set this to 1
+targetdir=${0%/*} # get script's own directory
+cd $targetdir/../examples
+source ../scripts/example-test-utils.sh
+
+# Run and verify each example
+
+declare -a arr=("helloRPC" "slack" "binary")
+for i in "${arr[@]}"
+do
+  $i/test-example.sh
+  if [ "$?" != "0" ]
+  then
+    failed=1
+  fi
+done
+
+
+echo "======================"
+if [ $failed == "1" ]
+then
+  echo Quark Examples: FAILED
+else
+  echo Quark Examples: PASSED
+fi
+echo "======================"
+
+exit $failed


### PR DESCRIPTION
This currently tests all combinations of `helloRPC`, `slack`, and `binary`. It's bash-based and has no dependencies other than quark itself. Tests are run according to the READMEs for each example, and output logs are scanned for expected output. Failure is recorded when the expected log output isn't there, or when child processes/scripts exit with non-zero status.

To verify all examples, run `scripts/test-examples.sh`.
To verify a single example, run the `test-example.sh` in that example's directory.