### PR TITLE
Raise exceptions on invalid casts and abstract/interface method calls for dynamically-typed backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ Latest
   * `quark.os.FS.userHomeDir()` is now `quark.os.getUserHomeDir()`.
   * `quark.os.Environment.ENV.get(key, default_value)` added.
 
+### Foreign-function interface
+
+* (!) Change how cast operator (`?`) works on dynamically-typed back-ends
+  (Python, Ruby, JavaScript). Previously casting on dynamically-typed back-ends
+  had no effect, now it is translated into an assertion that the value is
+  of that type which it is being cast into. The effect on FFI is that now,
+  you are required to subclass classes/interfaces if you implement them,
+  instead of relying on duck-typing.
+* Calling abstract/interface methods produces a readable error message,
+  instead of a simple assertion failure.
 
 0.6.74
 ------

--- a/examples/helloRPC/jsserver.js
+++ b/examples/helloRPC/jsserver.js
@@ -23,6 +23,8 @@ function HelloImpl() {
     };
 }
 
+HelloImpl.prototype = new hello.Hello()
+
 var implementation = new HelloImpl();
 var server = new hello.HelloServer(implementation);
 server.sendCORS(true);

--- a/examples/helloRPC/pyserver.py
+++ b/examples/helloRPC/pyserver.py
@@ -3,7 +3,7 @@
 import hello
 
 
-class HelloImpl(object):
+class HelloImpl(hello.Hello):
 
     def hello(self, request):
         res = hello.Response()

--- a/examples/helloRPC/rbserver.rb
+++ b/examples/helloRPC/rbserver.rb
@@ -4,7 +4,7 @@ require 'hello'
 Hello = ::Quark::Hello
 
 
-class HelloImpl
+class HelloImpl < Hello::Hello
 
     def hello(request)
         res = Hello::Response.new

--- a/examples/slack/gen-test/expected/out-node+bot.js.txt
+++ b/examples/slack/gen-test/expected/out-node+bot.js.txt
@@ -1,0 +1,1 @@
+Hello { type: 'hello', user: null, channel: null, timestamp: null }

--- a/examples/slack/gen-test/expected/out-node+bot.js.txt
+++ b/examples/slack/gen-test/expected/out-node+bot.js.txt
@@ -1,1 +1,0 @@
-Hello { type: 'hello', user: null, channel: null, timestamp: null }

--- a/quarkc/javascript.py
+++ b/quarkc/javascript.py
@@ -279,7 +279,11 @@ def get_field(expr, field):
     return "(%s).%s" % (expr, field)
 
 def cast(type, expr):
-    return expr
+    if type == '':  # TODO why does this happen?
+        return expr
+    assert expr
+    template = '_qrt.cast({expr}, function () {{ return {type}; }})'.format
+    return template(expr=expr, type=type)
 
 ## Literals
 

--- a/quarkc/javascript.py
+++ b/quarkc/javascript.py
@@ -17,6 +17,9 @@ from collections import OrderedDict
 from .compiler import BUILTIN
 from .helpers import *
 
+not_implemented_template = """\
+throw TypeError, '`{clazz}.{name}` is an abstract method';""".format
+
 ## Packaging
 
 def package(name, version, packages, srcs, deps):
@@ -170,7 +173,8 @@ def abstract_method(doc, clazz, type, name, parameters):
     params = ", ".join(parameters)
     full_name = "%s_%s" % (clazz, name)
     trailer = "%s.prototype.%s = %s;" % (clazz, name, full_name)
-    return "\n%sfunction %s(%s) { /* abstract */ }\n" % (doc, full_name, params) + trailer
+    body = not_implemented_template(clazz=clazz, name=name)
+    return "\n%sfunction %s(%s) { %s }\n" % (doc, full_name, params, body) + trailer
 
 ## Interface definition
 
@@ -182,7 +186,7 @@ def interface_method(doc, iface, type, name, parameters, body):
     full_name = "%s_%s" % (iface, name)
     trailer = "%s.prototype.%s = %s;" % (iface, name, full_name)
     if body is None:
-        body = " { /* interface */ }"
+        body = " { %s }" % not_implemented_template(clazz=iface, name=name)
 
     return "\n%sfunction %s(%s)%s\n" % (doc, full_name, params, body) + trailer
 

--- a/quarkc/lib/datawire-quark-core.rb
+++ b/quarkc/lib/datawire-quark-core.rb
@@ -1030,6 +1030,16 @@ module DatawireQuarkCore
     Codec.new
   end
 
+  def self.cast(value, &block)
+    type = begin block.call rescue Object end
+
+    unless value.is_a?(type) || value.nil?
+      raise TypeError, "`#{value.inspect}` is not an instance of `#{type}`"
+    end
+
+    value
+  end
+
   class Mutex
   end
 

--- a/quarkc/lib/primitives.astc
+++ b/quarkc/lib/primitives.astc
@@ -95,7 +95,7 @@ File(Import(Name(quark)), Include(url=io/datawire/quark/runtime/QObject.java),
 
   Primitive(Annotation(Name(mapping), Native(NativeCase(java,
       Fixed('Boolean')), NativeCase(py, Fixed('bool')), NativeCase(js,
-      Fixed('Boolean')), NativeCase(rb, Fixed('Object')))), Name(bool),
+      Fixed('Boolean')), NativeCase(rb, Fixed('::Object')))), Name(bool),
 
    MethodMacro(Type(Name(bool)), Name(__not__), Native(NativeCase(java,
       Fixed('!('), Var(Name(self), $type=1.quark.bool), Fixed(')')),
@@ -272,7 +272,7 @@ File(Import(Name(quark)), Include(url=io/datawire/quark/runtime/QObject.java),
 
   Primitive(Annotation(Name(mapping), Native(NativeCase(java, Fixed('Byte')),
      NativeCase(py, Fixed('int')), NativeCase(js, Fixed('Number')),
-     NativeCase(rb, Fixed('Integer')))), Name(byte), Type(Name(integral),
+     NativeCase(rb, Fixed('::Integer')))), Name(byte), Type(Name(integral),
     Type(Name(byte))),
 
    ConstructorMacro(Name(byte), Native(NativeCase(java, Fixed('new Byte()')),
@@ -295,7 +295,7 @@ File(Import(Name(quark)), Include(url=io/datawire/quark/runtime/QObject.java),
 
   Primitive(Annotation(Name(mapping), Native(NativeCase(java, Fixed('Short')),
      NativeCase(py, Fixed('int')), NativeCase(js, Fixed('Number')),
-     NativeCase(rb, Fixed('Integer')))), Name(short), Type(Name(integral),
+     NativeCase(rb, Fixed('::Integer')))), Name(short), Type(Name(integral),
     Type(Name(short))),
 
    ConstructorMacro(Name(short), Native(NativeCase(java, Fixed('new Short()')),
@@ -318,7 +318,7 @@ File(Import(Name(quark)), Include(url=io/datawire/quark/runtime/QObject.java),
 
   Primitive(Annotation(Name(mapping), Native(NativeCase(java,
       Fixed('Integer')), NativeCase(py, Fixed('int')), NativeCase(js,
-      Fixed('Number')), NativeCase(rb, Fixed('Integer')))), Name(int),
+      Fixed('Number')), NativeCase(rb, Fixed('::Integer')))), Name(int),
    Type(Name(integral), Type(Name(int))),
 
    ConstructorMacro(Name(int), Native(NativeCase(java, Fixed('new Integer()')),
@@ -356,7 +356,7 @@ File(Import(Name(quark)), Include(url=io/datawire/quark/runtime/QObject.java),
 
   Primitive(Annotation(Name(mapping), Native(NativeCase(java, Fixed('Long')),
      NativeCase(py, Fixed('long')), NativeCase(js, Fixed('Number')),
-     NativeCase(rb, Fixed('Integer')))), Name(long), Type(Name(integral),
+     NativeCase(rb, Fixed('::Integer')))), Name(long), Type(Name(integral),
     Type(Name(long))),
 
    ConstructorMacro(Name(long), Native(NativeCase(java, Fixed('new Long()')),
@@ -380,7 +380,7 @@ File(Import(Name(quark)), Include(url=io/datawire/quark/runtime/QObject.java),
 
   Primitive(Annotation(Name(mapping), Native(NativeCase(java, Fixed('Double')),
      NativeCase(py, Fixed('float')), NativeCase(js, Fixed('Number')),
-     NativeCase(rb, Fixed('Float')))), Name(float), Type(Name(numeric),
+     NativeCase(rb, Fixed('::Float')))), Name(float), Type(Name(numeric),
     Type(Name(float))),
 
    MethodMacro(Type(Name(float)), Name(__div__),
@@ -421,8 +421,8 @@ File(Import(Name(quark)), Include(url=io/datawire/quark/runtime/QObject.java),
      $type=1.quark.float.toJSON), $type=4.quark.JSONObject))),
 
   Primitive(Annotation(Name(mapping), Native(NativeCase(java, Fixed('String')),
-     NativeCase(py, Fixed('str')), NativeCase(js, Fixed('String')),
-     NativeCase(rb, Fixed('String')))), Name(String),
+     NativeCase(py, Fixed('unicode')), NativeCase(js, Fixed('String')),
+     NativeCase(rb, Fixed('::String')))), Name(String),
 
    MethodMacro(Type(Name(String)), Name(__add__),
     Param(Type(Name(String)), Name(other), $type=1.quark.String),

--- a/quarkc/lib/primitives.q
+++ b/quarkc/lib/primitives.q
@@ -37,7 +37,7 @@ namespace quark {
     primitive void {}
 
     // Ruby doesn't have a Boolean type, only TrueClass and FalseClass
-    @mapping($java{Boolean} $py{bool} $js{Boolean} $rb{Object})
+    @mapping($java{Boolean} $py{bool} $js{Boolean} $rb{::Object})
     primitive bool {
         macro bool __not__() $java{!($self)} $py{not ($self)} $rb{!($self)} $js{!($self)};
         macro bool __and__(bool other) $java{($self) && ($other)}
@@ -84,7 +84,7 @@ namespace quark {
         macro T __bitwise_not__() ${(~($self))};
     }
 
-    @mapping($java{Byte} $py{int} $js{Number} $rb{Integer})
+    @mapping($java{Byte} $py{int} $js{Number} $rb{::Integer})
     primitive byte extends integral<byte> {
         macro byte() $java{new Byte()}
                      $py{int()}
@@ -100,7 +100,7 @@ namespace quark {
     }
 
 
-    @mapping($java{Short} $py{int} $js{Number} $rb{Integer})
+    @mapping($java{Short} $py{int} $js{Number} $rb{::Integer})
     primitive short extends integral<short> {
         macro short() $java{new Short()}
                       $py{int()}
@@ -116,7 +116,7 @@ namespace quark {
     }
 
 
-    @mapping($java{Integer} $py{int} $js{Number} $rb{Integer})
+    @mapping($java{Integer} $py{int} $js{Number} $rb{::Integer})
     primitive int extends integral<int> {
         macro int() $java{new Integer()}
                     $py{int()}
@@ -141,7 +141,7 @@ namespace quark {
                                $js{($self)};
     }
 
-    @mapping($java{Long} $py{long} $js{Number} $rb{Integer})
+    @mapping($java{Long} $py{long} $js{Number} $rb{::Integer})
     primitive long extends integral<long> {
         macro long() $java{new Long()}
                      $py{int()}
@@ -158,7 +158,7 @@ namespace quark {
                              $js{($self)};
     }
 
-    @mapping($java{Double} $py{float} $js{Number} $rb{Float})
+    @mapping($java{Double} $py{float} $js{Number} $rb{::Float})
     primitive float extends numeric<float> {
         macro float __div__(float other) $java{($self) / ($other)}
                                          $py{float($self) / float($other)}
@@ -176,7 +176,7 @@ namespace quark {
         macro JSONObject __to_JSONObject() self.toJSON();
     }
 
-    @mapping($java{String} $py{str} $js{String} $rb{String})
+    @mapping($java{String} $py{unicode} $js{String} $rb{::String})
     primitive String {
         macro String __add__(String other) ${($self) + ($other)};
         macro int size()                   $java{($self).length()}

--- a/quarkc/lib/quark_runtime.js
+++ b/quarkc/lib/quark_runtime.js
@@ -58,6 +58,36 @@
     }
     exports.print = print;
 
+    /*
+     * Like instanceof operator, but robust against primitive types.
+     * Note, this is not robust against passing objects between iframes.
+     */
+    function is_instance_of(value, type) {
+        return ((value instanceof type)
+            || (type === String && typeof value === 'string')
+            || (type === Number && typeof value === 'number')
+            || (type === Boolean && typeof value === 'boolean')
+        );
+    }
+
+    function cast(value, callback) {
+        try {
+            var type = callback();
+            if (value == null || is_instance_of(value, type)) {
+                return value;
+            } else {
+                throw TypeError,
+                    '`' + value + '` is not an instance of `' + type + '`';
+            }
+        } catch (error) {
+            if (error instanceof ReferenceError) {
+                return value;
+            }
+            throw error;
+        }
+    }
+    exports.cast = cast;
+
     function modulo(a, b) {
         return (a % b + b) % b;
     }

--- a/quarkc/lib/quark_runtime.py
+++ b/quarkc/lib/quark_runtime.py
@@ -20,8 +20,7 @@ import base64
 __all__ = """os sys time _Map _List _println _toString _url_get _urlencode _JSONObject
              _HTTPRequest _HTTPResponse _default_codec _getClass
              _RuntimeFactory _Lock _Condition _TLS _TLSInitializer
-             _LoggerConfig _get_file_contents""".split()
-
+             _LoggerConfig _cast _get_file_contents""".split()
 
 _Map = dict
 
@@ -53,6 +52,17 @@ def _url_get(url):
         return urllib2.urlopen(url).read()
     except Exception:
         return "error"
+
+def _cast(value, callback):
+    try:
+        type = callback()
+    except:
+        type = object
+    if isinstance(value, type) or value is None:
+        return value
+    else:
+        template = '`{value}` is not an instance of `{type}`'.format
+        raise TypeError(template(value=repr(value), type=type))
 
 class _JSONObject(object):
     _backend = json

--- a/quarkc/lib/quark_runtime.py
+++ b/quarkc/lib/quark_runtime.py
@@ -58,6 +58,8 @@ def _cast(value, callback):
         type = callback()
     except:
         type = object
+    if type is unicode:
+        type = (unicode, str)
     if isinstance(value, type) or value is None:
         return value
     else:

--- a/quarkc/python.py
+++ b/quarkc/python.py
@@ -93,6 +93,10 @@ Indices and tables
 * :ref:`search`
 """
 
+not_implemented_template = """\
+raise NotImplementedError('`{clazz}.{name}` is an abstract method')""".format
+
+
 def package(name, version, packages, srcs, deps):
     fmt_dict = {"name": name,
                 "version": version,
@@ -221,7 +225,8 @@ def static_method(doc, clazz, type, name, parameters, body):
     return "\n@staticmethod\ndef %s(%s)%s" % (name, ", ".join(parameters), body_with_doc)
 
 def abstract_method(doc, clazz, type, name, parameters):
-    return "\ndef %s(%s):%s\n    assert False" % (name, ", ".join(["self"] + parameters), doc)
+    body = not_implemented_template(clazz=clazz, name=name)
+    return ("\ndef %s(%s):%s\n    " + body) % (name, ", ".join(["self"] + parameters), doc)
 
 ## Interface definition
 
@@ -234,7 +239,8 @@ def interface(doc, iface, parameters, bases, static_fields, methods):
     return result
 
 def interface_method(doc, iface, type, name, parameters, body):
-    if body is None: body = ":\n    assert False"
+    if body is None:
+        body = ":\n    " + not_implemented_template(clazz=iface, name=name)
     body_with_doc = ":" + doc + body[1:]
     return "\ndef %s(%s)%s" % (name, ", ".join(["self"] + parameters), body_with_doc)
 

--- a/quarkc/python.py
+++ b/quarkc/python.py
@@ -335,7 +335,9 @@ def get_field(expr, field):
     return "(%s).%s" % (expr, field)
 
 def cast(type, expr):
-    return expr
+    if type == '':
+        return expr
+    return '_cast({expr}, lambda: {type})'.format(expr=expr, type=type)
 
 ## Literals
 

--- a/quarkc/ruby.py
+++ b/quarkc/ruby.py
@@ -50,6 +50,9 @@ end
   spec.add_runtime_dependency '{module}', '= {version}'\
 """.format
 
+    not_implemented = """\
+raise NotImplementedError, '`{clazz}.{name}` is an abstract method'""".format
+
     class_ = """\
 def self.{alias}; {name}; end
 class {name} < {base}
@@ -258,7 +261,7 @@ def abstract_method(doc, clazz, type, name, parameters):
     return Templates.method(
         name=name,
         parameters=', '.join(parameters),
-        body='raise NotImplementedError, "this is an abstract method"',
+        body=Templates.not_implemented(clazz=clazz, name=name)
     )
 
 ## Interface definition
@@ -266,11 +269,13 @@ def abstract_method(doc, clazz, type, name, parameters):
 def interface(doc, iface, parameters, bases, static_fields, methods):
     return clazz(doc, False, iface, parameters, None, [], static_fields, [], [default_constructor(iface)], methods)
 
+
+
 def interface_method(doc, iface, type, name, parameters, body):
     return Templates.method(
         name=name,
         parameters=', '.join(parameters),
-        body=body or 'raise NotImplementedError, "this is an abstract method"',
+        body=body or Templates.not_implemented(clazz=iface, name=name)
     )
 
 ## Function definition

--- a/quarkc/ruby.py
+++ b/quarkc/ruby.py
@@ -388,8 +388,13 @@ def get_static_field(path, clazz, field):
     return full_ruby_name(path + [clazz]) + '.' + field
 
 def cast(type, expr):
+    if type == '':  # TODO why does this happen?
+        return expr
     assert expr
-    return expr
+    template = '::DatawireQuarkCore.cast({expr}) {{ {type} }}'.format
+    if not type.startswith('::'):
+        type = '::Quark.' + type
+    return template(expr=expr, type=type)
 
 ## Literals
 

--- a/quarkc/test/capture_output.py
+++ b/quarkc/test/capture_output.py
@@ -94,7 +94,7 @@ class Captured(object):
 
     def finish_capture(self, child):
         if child.isalive():
-            child.expect(pexpect.EOF)
+            child.expect(pexpect.EOF, timeout=90)
         self.output = child.logfile_read.get_data()
 
 

--- a/quarkc/test/ffi/expected/js/dependencies/dependencies_md/index.js
+++ b/quarkc/test/ffi/expected/js/dependencies/dependencies_md/index.js
@@ -11,7 +11,7 @@ function Root__init_fields__() {}
 Root.prototype.__init_fields__ = Root__init_fields__;
 
 function Root__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 Root.prototype._getClass = Root__getClass;
 

--- a/quarkc/test/ffi/expected/js/org_example_foo/org_example_foo_md/index.js
+++ b/quarkc/test/ffi/expected/js/org_example_foo/org_example_foo_md/index.js
@@ -18,14 +18,14 @@ function org_example_foo_Foo_test_Method__init_fields__() {
 org_example_foo_Foo_test_Method.prototype.__init_fields__ = org_example_foo_Foo_test_Method__init_fields__;
 
 function org_example_foo_Foo_test_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return org.example.foo.Foo; });
     (obj).test();
     return null;
 }
 org_example_foo_Foo_test_Method.prototype.invoke = org_example_foo_Foo_test_Method_invoke;
 
 function org_example_foo_Foo_test_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 org_example_foo_Foo_test_Method.prototype._getClass = org_example_foo_Foo_test_Method__getClass;
 
@@ -60,7 +60,7 @@ function org_example_foo_Foo_construct(args) {
 org_example_foo_Foo.prototype.construct = org_example_foo_Foo_construct;
 
 function org_example_foo_Foo__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 org_example_foo_Foo.prototype._getClass = org_example_foo_Foo__getClass;
 
@@ -83,7 +83,7 @@ function Root__init_fields__() {}
 Root.prototype.__init_fields__ = Root__init_fields__;
 Root.org_example_foo_Foo_md = org_example_foo_Foo.singleton;
 function Root__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 Root.prototype._getClass = Root__getClass;
 

--- a/quarkc/test/ffi/expected/js/overlapping_namespaces/overlapping_namespace_md/index.js
+++ b/quarkc/test/ffi/expected/js/overlapping_namespaces/overlapping_namespace_md/index.js
@@ -18,14 +18,14 @@ function org_example_bar_Bar_test_Method__init_fields__() {
 org_example_bar_Bar_test_Method.prototype.__init_fields__ = org_example_bar_Bar_test_Method__init_fields__;
 
 function org_example_bar_Bar_test_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return org.example.bar.Bar; });
     (obj).test();
     return null;
 }
 org_example_bar_Bar_test_Method.prototype.invoke = org_example_bar_Bar_test_Method_invoke;
 
 function org_example_bar_Bar_test_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 org_example_bar_Bar_test_Method.prototype._getClass = org_example_bar_Bar_test_Method__getClass;
 
@@ -60,7 +60,7 @@ function org_example_bar_Bar_construct(args) {
 org_example_bar_Bar.prototype.construct = org_example_bar_Bar_construct;
 
 function org_example_bar_Bar__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 org_example_bar_Bar.prototype._getClass = org_example_bar_Bar__getClass;
 
@@ -83,7 +83,7 @@ function Root__init_fields__() {}
 Root.prototype.__init_fields__ = Root__init_fields__;
 Root.org_example_bar_Bar_md = org_example_bar_Bar.singleton;
 function Root__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 Root.prototype._getClass = Root__getClass;
 

--- a/quarkc/test/ffi/expected/js/package/package_md/index.js
+++ b/quarkc/test/ffi/expected/js/package/package_md/index.js
@@ -18,14 +18,14 @@ function test_Test_go_Method__init_fields__() {
 test_Test_go_Method.prototype.__init_fields__ = test_Test_go_Method__init_fields__;
 
 function test_Test_go_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return test.Test; });
     (obj).go();
     return null;
 }
 test_Test_go_Method.prototype.invoke = test_Test_go_Method_invoke;
 
 function test_Test_go_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 test_Test_go_Method.prototype._getClass = test_Test_go_Method__getClass;
 
@@ -60,7 +60,7 @@ function test_Test_construct(args) {
 test_Test.prototype.construct = test_Test_construct;
 
 function test_Test__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 test_Test.prototype._getClass = test_Test__getClass;
 
@@ -87,14 +87,14 @@ function test_subtest_Test_go_Method__init_fields__() {
 test_subtest_Test_go_Method.prototype.__init_fields__ = test_subtest_Test_go_Method__init_fields__;
 
 function test_subtest_Test_go_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return test.subtest.Test; });
     (obj).go();
     return null;
 }
 test_subtest_Test_go_Method.prototype.invoke = test_subtest_Test_go_Method_invoke;
 
 function test_subtest_Test_go_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 test_subtest_Test_go_Method.prototype._getClass = test_subtest_Test_go_Method__getClass;
 
@@ -129,7 +129,7 @@ function test_subtest_Test_construct(args) {
 test_subtest_Test.prototype.construct = test_subtest_Test_construct;
 
 function test_subtest_Test__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 test_subtest_Test.prototype._getClass = test_subtest_Test__getClass;
 
@@ -153,7 +153,7 @@ Root.prototype.__init_fields__ = Root__init_fields__;
 Root.test_Test_md = test_Test.singleton;
 Root.test_subtest_Test_md = test_subtest_Test.singleton;
 function Root__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 Root.prototype._getClass = Root__getClass;
 

--- a/quarkc/test/ffi/expected/js/package/test/index.js
+++ b/quarkc/test/ffi/expected/js/package/test/index.js
@@ -40,7 +40,7 @@ Test.prototype._getField = Test__getField;
 
 function Test__setField(name, value) {
     if (_qrt.equals((name), ("name"))) {
-        (this).name = value;
+        (this).name = _qrt.cast(value, function () { return String; });
     }
 }
 Test.prototype._setField = Test__setField;

--- a/quarkc/test/ffi/expected/js/package/test/subtest/index.js
+++ b/quarkc/test/ffi/expected/js/package/test/subtest/index.js
@@ -38,7 +38,7 @@ Test.prototype._getField = Test__getField;
 
 function Test__setField(name, value) {
     if (_qrt.equals((name), ("size"))) {
-        (this).size = value;
+        (this).size = _qrt.cast(value, function () { return Number; });
     }
 }
 Test.prototype._setField = Test__setField;

--- a/quarkc/test/ffi/expected/js/signatures/classes/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/classes/index.js
@@ -21,12 +21,12 @@ function Overload__init_fields__() {
 Overload.prototype.__init_fields__ = Overload__init_fields__;
 Overload.classes_Overload_ref = quark_ffi_signatures_md.Root.classes_Overload_md;
 function Overload___add__(o) {
-    return null;
+    return _qrt.cast(null, function () { return Overload; });
 }
 Overload.prototype.__add__ = Overload___add__;
 
 function Overload___mul__(o) {
-    return null;
+    return _qrt.cast(null, function () { return Overload; });
 }
 Overload.prototype.__mul__ = Overload___mul__;
 
@@ -48,7 +48,7 @@ Overload.prototype._getField = Overload__getField;
 
 function Overload__setField(name, value) {
     if (_qrt.equals((name), ("name"))) {
-        (this).name = value;
+        (this).name = _qrt.cast(value, function () { return String; });
     }
 }
 Overload.prototype._setField = Overload__setField;
@@ -118,7 +118,7 @@ function test_size__init_fields__() {
 test_size.prototype.__init_fields__ = test_size__init_fields__;
 test_size.classes_test_size_ref = quark_ffi_signatures_md.Root.classes_test_size_md;
 function test_size_does(expected) {
-    return null;
+    return _qrt.cast(null, function () { return test_size; });
 }
 test_size.prototype.does = test_size_does;
 
@@ -137,7 +137,7 @@ test_size.prototype._getField = test_size__getField;
 
 function test_size__setField(name, value) {
     if (_qrt.equals((name), ("what"))) {
-        (this).what = value;
+        (this).what = _qrt.cast(value, function () { return String; });
     }
 }
 test_size.prototype._setField = test_size__setField;
@@ -158,12 +158,12 @@ function test_startsWith__init_fields__() {
 test_startsWith.prototype.__init_fields__ = test_startsWith__init_fields__;
 test_startsWith.classes_test_startsWith_ref = quark_ffi_signatures_md.Root.classes_test_startsWith_md;
 function test_startsWith_that(_that) {
-    return null;
+    return _qrt.cast(null, function () { return test_startsWith; });
 }
 test_startsWith.prototype.that = test_startsWith_that;
 
 function test_startsWith_does(expected) {
-    return null;
+    return _qrt.cast(null, function () { return test_startsWith; });
 }
 test_startsWith.prototype.does = test_startsWith_does;
 
@@ -185,10 +185,10 @@ test_startsWith.prototype._getField = test_startsWith__getField;
 
 function test_startsWith__setField(name, value) {
     if (_qrt.equals((name), ("what"))) {
-        (this).what = value;
+        (this).what = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("_that"))) {
-        (this)._that = value;
+        (this)._that = _qrt.cast(value, function () { return String; });
     }
 }
 test_startsWith.prototype._setField = test_startsWith__setField;
@@ -209,12 +209,12 @@ function test_endsWith__init_fields__() {
 test_endsWith.prototype.__init_fields__ = test_endsWith__init_fields__;
 test_endsWith.classes_test_endsWith_ref = quark_ffi_signatures_md.Root.classes_test_endsWith_md;
 function test_endsWith_that(_that) {
-    return null;
+    return _qrt.cast(null, function () { return test_endsWith; });
 }
 test_endsWith.prototype.that = test_endsWith_that;
 
 function test_endsWith_does(expected) {
-    return null;
+    return _qrt.cast(null, function () { return test_endsWith; });
 }
 test_endsWith.prototype.does = test_endsWith_does;
 
@@ -236,10 +236,10 @@ test_endsWith.prototype._getField = test_endsWith__getField;
 
 function test_endsWith__setField(name, value) {
     if (_qrt.equals((name), ("what"))) {
-        (this).what = value;
+        (this).what = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("_that"))) {
-        (this)._that = value;
+        (this)._that = _qrt.cast(value, function () { return String; });
     }
 }
 test_endsWith.prototype._setField = test_endsWith__setField;
@@ -260,12 +260,12 @@ function test_find__init_fields__() {
 test_find.prototype.__init_fields__ = test_find__init_fields__;
 test_find.classes_test_find_ref = quark_ffi_signatures_md.Root.classes_test_find_md;
 function test_find_that(_that) {
-    return null;
+    return _qrt.cast(null, function () { return test_find; });
 }
 test_find.prototype.that = test_find_that;
 
 function test_find_does(expected) {
-    return null;
+    return _qrt.cast(null, function () { return test_find; });
 }
 test_find.prototype.does = test_find_does;
 
@@ -287,10 +287,10 @@ test_find.prototype._getField = test_find__getField;
 
 function test_find__setField(name, value) {
     if (_qrt.equals((name), ("what"))) {
-        (this).what = value;
+        (this).what = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("_that"))) {
-        (this)._that = value;
+        (this)._that = _qrt.cast(value, function () { return String; });
     }
 }
 test_find.prototype._setField = test_find__setField;
@@ -312,12 +312,12 @@ function test_substring__init_fields__() {
 test_substring.prototype.__init_fields__ = test_substring__init_fields__;
 test_substring.classes_test_substring_ref = quark_ffi_signatures_md.Root.classes_test_substring_md;
 function test_substring_that(start, end) {
-    return null;
+    return _qrt.cast(null, function () { return test_substring; });
 }
 test_substring.prototype.that = test_substring_that;
 
 function test_substring_does(expected) {
-    return null;
+    return _qrt.cast(null, function () { return test_substring; });
 }
 test_substring.prototype.does = test_substring_does;
 
@@ -342,13 +342,13 @@ test_substring.prototype._getField = test_substring__getField;
 
 function test_substring__setField(name, value) {
     if (_qrt.equals((name), ("what"))) {
-        (this).what = value;
+        (this).what = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("start"))) {
-        (this).start = value;
+        (this).start = _qrt.cast(value, function () { return Number; });
     }
     if (_qrt.equals((name), ("end"))) {
-        (this).end = value;
+        (this).end = _qrt.cast(value, function () { return Number; });
     }
 }
 test_substring.prototype._setField = test_substring__setField;
@@ -370,12 +370,12 @@ function test_replace__init_fields__() {
 test_replace.prototype.__init_fields__ = test_replace__init_fields__;
 test_replace.classes_test_replace_ref = quark_ffi_signatures_md.Root.classes_test_replace_md;
 function test_replace_that(start, end) {
-    return null;
+    return _qrt.cast(null, function () { return test_replace; });
 }
 test_replace.prototype.that = test_replace_that;
 
 function test_replace_does(expected) {
-    return null;
+    return _qrt.cast(null, function () { return test_replace; });
 }
 test_replace.prototype.does = test_replace_does;
 
@@ -400,13 +400,13 @@ test_replace.prototype._getField = test_replace__getField;
 
 function test_replace__setField(name, value) {
     if (_qrt.equals((name), ("what"))) {
-        (this).what = value;
+        (this).what = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("start"))) {
-        (this).start = value;
+        (this).start = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("end"))) {
-        (this).end = value;
+        (this).end = _qrt.cast(value, function () { return String; });
     }
 }
 test_replace.prototype._setField = test_replace__setField;
@@ -429,17 +429,17 @@ function test_join__init_fields__() {
 test_join.prototype.__init_fields__ = test_join__init_fields__;
 test_join.classes_test_join_ref = quark_ffi_signatures_md.Root.classes_test_join_md;
 function test_join_that() {
-    return null;
+    return _qrt.cast(null, function () { return test_join; });
 }
 test_join.prototype.that = test_join_that;
 
 function test_join_a(part) {
-    return null;
+    return _qrt.cast(null, function () { return test_join; });
 }
 test_join.prototype.a = test_join_a;
 
 function test_join_does(expected) {
-    return null;
+    return _qrt.cast(null, function () { return test_join; });
 }
 test_join.prototype.does = test_join_does;
 
@@ -467,16 +467,16 @@ test_join.prototype._getField = test_join__getField;
 
 function test_join__setField(name, value) {
     if (_qrt.equals((name), ("what"))) {
-        (this).what = value;
+        (this).what = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("parts"))) {
-        (this).parts = value;
+        (this).parts = _qrt.cast(value, function () { return Array; });
     }
     if (_qrt.equals((name), ("strparts"))) {
-        (this).strparts = value;
+        (this).strparts = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("sep"))) {
-        (this).sep = value;
+        (this).sep = _qrt.cast(value, function () { return String; });
     }
 }
 test_join.prototype._setField = test_join__setField;
@@ -498,12 +498,12 @@ function test_split__init_fields__() {
 test_split.prototype.__init_fields__ = test_split__init_fields__;
 test_split.classes_test_split_ref = quark_ffi_signatures_md.Root.classes_test_split_md;
 function test_split_that(what) {
-    return null;
+    return _qrt.cast(null, function () { return test_split; });
 }
 test_split.prototype.that = test_split_that;
 
 function test_split_does(expected) {
-    return null;
+    return _qrt.cast(null, function () { return test_split; });
 }
 test_split.prototype.does = test_split_does;
 
@@ -528,13 +528,13 @@ test_split.prototype._getField = test_split__getField;
 
 function test_split__setField(name, value) {
     if (_qrt.equals((name), ("what"))) {
-        (this).what = value;
+        (this).what = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("sep"))) {
-        (this).sep = value;
+        (this).sep = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("altsep"))) {
-        (this).altsep = value;
+        (this).altsep = _qrt.cast(value, function () { return String; });
     }
 }
 test_split.prototype._setField = test_split__setField;

--- a/quarkc/test/ffi/expected/js/signatures/classes/stuff/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/classes/stuff/index.js
@@ -16,7 +16,7 @@ function Test__init_fields__() {}
 Test.prototype.__init_fields__ = Test__init_fields__;
 Test.classes_stuff_Test_ref = quark_ffi_signatures_md.Root.classes_stuff_Test_md;
 function Test_foo(t) {
-    return null;
+    return _qrt.cast(null, function () { return Test; });
 }
 Test.prototype.foo = Test_foo;
 

--- a/quarkc/test/ffi/expected/js/signatures/docs/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/docs/index.js
@@ -48,7 +48,7 @@ Test.prototype._getField = Test__getField;
 
 function Test__setField(name, value) {
     if (_qrt.equals((name), ("name"))) {
-        (this).name = value;
+        (this).name = _qrt.cast(value, function () { return String; });
     }
 }
 Test.prototype._setField = Test__setField;

--- a/quarkc/test/ffi/expected/js/signatures/functions/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/functions/index.js
@@ -2,6 +2,6 @@ var _qrt = require("quark/quark_runtime.js");
 
 
 function factorial(n) {
-    return null;
+    return _qrt.cast(null, function () { return Number; });
 }
 exports.factorial = factorial;

--- a/quarkc/test/ffi/expected/js/signatures/generics/ccc/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/generics/ccc/index.js
@@ -16,7 +16,7 @@ function TLSContextInitializer__init_fields__() {}
 TLSContextInitializer.prototype.__init_fields__ = TLSContextInitializer__init_fields__;
 TLSContextInitializer.generics_ccc_TLSContextInitializer_ref = quark_ffi_signatures_md.Root.generics_ccc_TLSContextInitializer_md;
 function TLSContextInitializer_getValue() {
-    return null;
+    return _qrt.cast(null, function () { return Context; });
 }
 TLSContextInitializer.prototype.getValue = TLSContextInitializer_getValue;
 
@@ -49,12 +49,12 @@ Context._current = null;
 Context.generics_ccc_Context_ref = quark_ffi_signatures_md.Root.generics_ccc_Context_md;
 Context.generics_ccc_TLS_generics_ccc_Context__ref = quark_ffi_signatures_md.Root.generics_ccc_TLS_generics_ccc_Context__md;
 function Context_current() {
-    return null;
+    return _qrt.cast(null, function () { return Context; });
 }
 Context.current = Context_current;
 
 function Context_global() {
-    return null;
+    return _qrt.cast(null, function () { return Context; });
 }
 Context.global = Context_global;
 
@@ -79,13 +79,13 @@ Context.prototype._getField = Context__getField;
 
 function Context__setField(name, value) {
     if (_qrt.equals((name), ("_global"))) {
-        Context._global = value;
+        Context._global = _qrt.cast(value, function () { return Context; });
     }
     if (_qrt.equals((name), ("_current"))) {
-        Context._current = value;
+        Context._current = _qrt.cast(value, function () { return TLS; });
     }
     if (_qrt.equals((name), ("parent"))) {
-        (this).parent = value;
+        (this).parent = _qrt.cast(value, function () { return Context; });
     }
 }
 Context.prototype._setField = Context__setField;
@@ -99,7 +99,7 @@ exports.TLSInitializer = TLSInitializer;
 function TLSInitializer__init_fields__() {}
 TLSInitializer.prototype.__init_fields__ = TLSInitializer__init_fields__;
 TLSInitializer.generics_ccc_TLSInitializer_quark_Object__ref = quark_ffi_signatures_md.Root.generics_ccc_TLSInitializer_quark_Object__md;
-function TLSInitializer_getValue() { /* interface */ }
+function TLSInitializer_getValue() { throw TypeError, '`TLSInitializer.getValue` is an abstract method'; }
 TLSInitializer.prototype.getValue = TLSInitializer_getValue;
 
 // CLASS TLS
@@ -115,7 +115,7 @@ function TLS__init_fields__() {
 TLS.prototype.__init_fields__ = TLS__init_fields__;
 
 function TLS_getValue() {
-    return null;
+    return _qrt.cast(null, function () { return T; });
 }
 TLS.prototype.getValue = TLS_getValue;
 
@@ -134,7 +134,7 @@ TLS.prototype._getField = TLS__getField;
 
 function TLS__setField(name, value) {
     if (_qrt.equals((name), ("_value"))) {
-        (this)._value = value;
+        (this)._value = _qrt.cast(value, function () { return T; });
     }
 }
 TLS.prototype._setField = TLS__setField;

--- a/quarkc/test/ffi/expected/js/signatures/generics/constructors/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/generics/constructors/index.js
@@ -19,7 +19,7 @@ function Box__init_fields__() {
 Box.prototype.__init_fields__ = Box__init_fields__;
 Box.generics_constructors_Box_quark_Object__ref = quark_ffi_signatures_md.Root.generics_constructors_Box_quark_Object__md;
 function Box_get() {
-    return null;
+    return _qrt.cast(null, function () { return T; });
 }
 Box.prototype.get = Box_get;
 
@@ -38,7 +38,7 @@ Box.prototype._getField = Box__getField;
 
 function Box__setField(name, value) {
     if (_qrt.equals((name), ("contents"))) {
-        (this).contents = value;
+        (this).contents = _qrt.cast(value, function () { return T; });
     }
 }
 Box.prototype._setField = Box__setField;

--- a/quarkc/test/ffi/expected/js/signatures/generics/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/generics/index.js
@@ -27,7 +27,7 @@ function Box_set(contents) {}
 Box.prototype.set = Box_set;
 
 function Box_get() {
-    return null;
+    return _qrt.cast(null, function () { return T; });
 }
 Box.prototype.get = Box_get;
 
@@ -46,7 +46,7 @@ Box.prototype._getField = Box__getField;
 
 function Box__setField(name, value) {
     if (_qrt.equals((name), ("contents"))) {
-        (this).contents = value;
+        (this).contents = _qrt.cast(value, function () { return T; });
     }
 }
 Box.prototype._setField = Box__setField;
@@ -69,7 +69,7 @@ function Crate_set(stuff) {}
 Crate.prototype.set = Crate_set;
 
 function Crate_get() {
-    return null;
+    return _qrt.cast(null, function () { return T; });
 }
 Crate.prototype.get = Crate_get;
 
@@ -91,10 +91,10 @@ Crate.prototype._getField = Crate__getField;
 
 function Crate__setField(name, value) {
     if (_qrt.equals((name), ("box"))) {
-        (this).box = value;
+        (this).box = _qrt.cast(value, function () { return Box; });
     }
     if (_qrt.equals((name), ("ibox"))) {
-        (this).ibox = value;
+        (this).ibox = _qrt.cast(value, function () { return Box; });
     }
 }
 Crate.prototype._setField = Crate__setField;
@@ -125,7 +125,7 @@ Sack.prototype._getField = Sack__getField;
 
 function Sack__setField(name, value) {
     if (_qrt.equals((name), ("ints"))) {
-        (this).ints = value;
+        (this).ints = _qrt.cast(value, function () { return Box; });
     }
 }
 Sack.prototype._setField = Sack__setField;
@@ -147,7 +147,7 @@ Matrix.generics_Matrix_quark_Object__ref = quark_ffi_signatures_md.Root.generics
 Matrix.quark_List_quark_List_quark_Object___ref = quark_ffi_signatures_md.Root.quark_List_quark_List_quark_Object___md;
 Matrix.quark_List_quark_Object__ref = quark_ffi_signatures_md.Root.quark_List_quark_Object__md;
 function Matrix___get__(i, j) {
-    return null;
+    return _qrt.cast(null, function () { return T; });
 }
 Matrix.prototype.__get__ = Matrix___get__;
 
@@ -175,13 +175,13 @@ Matrix.prototype._getField = Matrix__getField;
 
 function Matrix__setField(name, value) {
     if (_qrt.equals((name), ("width"))) {
-        (this).width = value;
+        (this).width = _qrt.cast(value, function () { return Number; });
     }
     if (_qrt.equals((name), ("height"))) {
-        (this).height = value;
+        (this).height = _qrt.cast(value, function () { return Number; });
     }
     if (_qrt.equals((name), ("columns"))) {
-        (this).columns = value;
+        (this).columns = _qrt.cast(value, function () { return Array; });
     }
 }
 Matrix.prototype._setField = Matrix__setField;

--- a/quarkc/test/ffi/expected/js/signatures/generics/pkg/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/generics/pkg/index.js
@@ -16,11 +16,11 @@ function Foo__init_fields__() {}
 Foo.prototype.__init_fields__ = Foo__init_fields__;
 Foo.generics_pkg_Foo_quark_Object__ref = quark_ffi_signatures_md.Root.generics_pkg_Foo_quark_Object__md;
 function Foo_foo() {
-    return null;
+    return _qrt.cast(null, function () { return T; });
 }
 Foo.prototype.foo = Foo_foo;
 
-function Foo_get() { /* interface */ }
+function Foo_get() { throw TypeError, '`Foo.get` is an abstract method'; }
 Foo.prototype.get = Foo_get;
 
 // CLASS StringFoo
@@ -33,7 +33,7 @@ function StringFoo__init_fields__() {}
 StringFoo.prototype.__init_fields__ = StringFoo__init_fields__;
 StringFoo.generics_pkg_StringFoo_ref = quark_ffi_signatures_md.Root.generics_pkg_StringFoo_md;
 function StringFoo_get() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 StringFoo.prototype.get = StringFoo_get;
 
@@ -51,7 +51,7 @@ function StringFoo__setField(name, value) {}
 StringFoo.prototype._setField = StringFoo__setField;
 
 function StringFoo_foo() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 StringFoo.prototype.foo = StringFoo_foo;
 
@@ -82,7 +82,7 @@ Box.prototype._getField = Box__getField;
 
 function Box__setField(name, value) {
     if (_qrt.equals((name), ("contents"))) {
-        (this).contents = value;
+        (this).contents = _qrt.cast(value, function () { return T; });
     }
 }
 Box.prototype._setField = Box__setField;
@@ -116,7 +116,7 @@ StringBox.prototype._getField = StringBox__getField;
 
 function StringBox__setField(name, value) {
     if (_qrt.equals((name), ("contents"))) {
-        (this).contents = value;
+        (this).contents = _qrt.cast(value, function () { return String; });
     }
 }
 StringBox.prototype._setField = StringBox__setField;

--- a/quarkc/test/ffi/expected/js/signatures/inheritance/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/inheritance/index.js
@@ -42,7 +42,7 @@ Base.prototype._getField = Base__getField;
 
 function Base__setField(name, value) {
     if (_qrt.equals((name), ("name"))) {
-        (this).name = value;
+        (this).name = _qrt.cast(value, function () { return String; });
     }
 }
 Base.prototype._setField = Base__setField;
@@ -83,13 +83,13 @@ Test.prototype._getField = Test__getField;
 
 function Test__setField(name, value) {
     if (_qrt.equals((name), ("name"))) {
-        (this).name = value;
+        (this).name = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("mumble"))) {
-        (this).mumble = value;
+        (this).mumble = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("later"))) {
-        (this).later = value;
+        (this).later = _qrt.cast(value, function () { return String; });
     }
 }
 Test.prototype._setField = Test__setField;
@@ -121,7 +121,7 @@ A.prototype._getField = A__getField;
 
 function A__setField(name, value) {
     if (_qrt.equals((name), ("name"))) {
-        (this).name = value;
+        (this).name = _qrt.cast(value, function () { return String; });
     }
 }
 A.prototype._setField = A__setField;
@@ -157,7 +157,7 @@ B.prototype._getField = B__getField;
 
 function B__setField(name, value) {
     if (_qrt.equals((name), ("name"))) {
-        (this).name = value;
+        (this).name = _qrt.cast(value, function () { return String; });
     }
 }
 B.prototype._setField = B__setField;
@@ -193,7 +193,7 @@ C.prototype._getField = C__getField;
 
 function C__setField(name, value) {
     if (_qrt.equals((name), ("name"))) {
-        (this).name = value;
+        (this).name = _qrt.cast(value, function () { return String; });
     }
 }
 C.prototype._setField = C__setField;
@@ -252,7 +252,7 @@ Y.prototype._getField = Y__getField;
 
 function Y__setField(name, value) {
     if (_qrt.equals((name), ("name"))) {
-        (this).name = value;
+        (this).name = _qrt.cast(value, function () { return String; });
     }
 }
 Y.prototype._setField = Y__setField;
@@ -267,7 +267,7 @@ function Message__init_fields__() {}
 Message.prototype.__init_fields__ = Message__init_fields__;
 Message.inheritance_Message_ref = quark_ffi_signatures_md.Root.inheritance_Message_md;
 function Message_encode() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 Message.prototype.encode = Message_encode;
 
@@ -324,7 +324,7 @@ function Pong__init_fields__() {
 Pong.prototype.__init_fields__ = Pong__init_fields__;
 Pong.inheritance_Pong_ref = quark_ffi_signatures_md.Root.inheritance_Pong_md;
 function Pong_toString() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 Pong.prototype.toString = Pong_toString;
 

--- a/quarkc/test/ffi/expected/js/signatures/inheritance/pets/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/inheritance/pets/index.js
@@ -15,7 +15,7 @@ exports.Pet = Pet;
 function Pet__init_fields__() {}
 Pet.prototype.__init_fields__ = Pet__init_fields__;
 
-function Pet_greet() { /* abstract */ }
+function Pet_greet() { throw TypeError, '`Pet.greet` is an abstract method'; }
 Pet.prototype.greet = Pet_greet;
 
 // CLASS Cat

--- a/quarkc/test/ffi/expected/js/signatures/inheritance/super_/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/inheritance/super_/index.js
@@ -36,7 +36,7 @@ A.prototype._getField = A__getField;
 
 function A__setField(name, value) {
     if (_qrt.equals((name), ("name"))) {
-        (this).name = value;
+        (this).name = _qrt.cast(value, function () { return String; });
     }
 }
 A.prototype._setField = A__setField;
@@ -72,7 +72,7 @@ B.prototype._getField = B__getField;
 
 function B__setField(name, value) {
     if (_qrt.equals((name), ("name"))) {
-        (this).name = value;
+        (this).name = _qrt.cast(value, function () { return String; });
     }
 }
 B.prototype._setField = B__setField;

--- a/quarkc/test/ffi/expected/js/signatures/inheritance/use_before_def/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/inheritance/use_before_def/index.js
@@ -57,7 +57,7 @@ Foo.prototype._getField = Foo__getField;
 
 function Foo__setField(name, value) {
     if (_qrt.equals((name), ("name"))) {
-        (this).name = value;
+        (this).name = _qrt.cast(value, function () { return String; });
     }
 }
 Foo.prototype._setField = Foo__setField;

--- a/quarkc/test/ffi/expected/js/signatures/interfaces/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/interfaces/index.js
@@ -15,7 +15,7 @@ exports.A = A;
 function A__init_fields__() {}
 A.prototype.__init_fields__ = A__init_fields__;
 A.interfaces_A_ref = quark_ffi_signatures_md.Root.interfaces_A_md;
-function A_foo() { /* interface */ }
+function A_foo() { throw TypeError, '`A.foo` is an abstract method'; }
 A.prototype.foo = A_foo;
 
 function A_bar() {}
@@ -195,13 +195,13 @@ function Foo__init_fields__() {}
 Foo.prototype.__init_fields__ = Foo__init_fields__;
 Foo.interfaces_Foo_ref = quark_ffi_signatures_md.Root.interfaces_Foo_md;
 Foo.quark_List_quark_String__ref = quark_ffi_signatures_md.Root.quark_List_quark_String__md;
-function Foo_m1() { /* interface */ }
+function Foo_m1() { throw TypeError, '`Foo.m1` is an abstract method'; }
 Foo.prototype.m1 = Foo_m1;
 
-function Foo_m2(arg) { /* interface */ }
+function Foo_m2(arg) { throw TypeError, '`Foo.m2` is an abstract method'; }
 Foo.prototype.m2 = Foo_m2;
 
-function Foo_m3(args) { /* interface */ }
+function Foo_m3(args) { throw TypeError, '`Foo.m3` is an abstract method'; }
 Foo.prototype.m3 = Foo_m3;
 
 // CLASS Bar
@@ -213,13 +213,13 @@ exports.Bar = Bar;
 function Bar__init_fields__() {}
 Bar.prototype.__init_fields__ = Bar__init_fields__;
 Bar.interfaces_Bar_quark_Object__ref = quark_ffi_signatures_md.Root.interfaces_Bar_quark_Object__md;
-function Bar_m1() { /* interface */ }
+function Bar_m1() { throw TypeError, '`Bar.m1` is an abstract method'; }
 Bar.prototype.m1 = Bar_m1;
 
-function Bar_m2(arg) { /* interface */ }
+function Bar_m2(arg) { throw TypeError, '`Bar.m2` is an abstract method'; }
 Bar.prototype.m2 = Bar_m2;
 
-function Bar_m3(args) { /* interface */ }
+function Bar_m3(args) { throw TypeError, '`Bar.m3` is an abstract method'; }
 Bar.prototype.m3 = Bar_m3;
 
 // CLASS Baz

--- a/quarkc/test/ffi/expected/js/signatures/quark_ffi_signatures_md/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/quark_ffi_signatures_md/index.js
@@ -18,14 +18,14 @@ function generics_Box_quark_Object__set_Method__init_fields__() {
 generics_Box_quark_Object__set_Method.prototype.__init_fields__ = generics_Box_quark_Object__set_Method__init_fields__;
 
 function generics_Box_quark_Object__set_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.Box; });
     (obj).set((args)[0]);
     return null;
 }
 generics_Box_quark_Object__set_Method.prototype.invoke = generics_Box_quark_Object__set_Method_invoke;
 
 function generics_Box_quark_Object__set_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_Box_quark_Object__set_Method.prototype._getClass = generics_Box_quark_Object__set_Method__getClass;
 
@@ -51,13 +51,13 @@ function generics_Box_quark_Object__get_Method__init_fields__() {
 generics_Box_quark_Object__get_Method.prototype.__init_fields__ = generics_Box_quark_Object__get_Method__init_fields__;
 
 function generics_Box_quark_Object__get_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.Box; });
     return (obj).get();
 }
 generics_Box_quark_Object__get_Method.prototype.invoke = generics_Box_quark_Object__get_Method_invoke;
 
 function generics_Box_quark_Object__get_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_Box_quark_Object__get_Method.prototype._getClass = generics_Box_quark_Object__get_Method__getClass;
 
@@ -92,7 +92,7 @@ function generics_Box_quark_Object__construct(args) {
 generics_Box_quark_Object_.prototype.construct = generics_Box_quark_Object__construct;
 
 function generics_Box_quark_Object___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_Box_quark_Object_.prototype._getClass = generics_Box_quark_Object___getClass;
 
@@ -119,14 +119,14 @@ function generics_Box_quark_int__set_Method__init_fields__() {
 generics_Box_quark_int__set_Method.prototype.__init_fields__ = generics_Box_quark_int__set_Method__init_fields__;
 
 function generics_Box_quark_int__set_Method_invoke(object, args) {
-    var obj = object;
-    (obj).set((args)[0]);
+    var obj = _qrt.cast(object, function () { return generics.Box; });
+    (obj).set(_qrt.cast((args)[0], function () { return Number; }));
     return null;
 }
 generics_Box_quark_int__set_Method.prototype.invoke = generics_Box_quark_int__set_Method_invoke;
 
 function generics_Box_quark_int__set_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_Box_quark_int__set_Method.prototype._getClass = generics_Box_quark_int__set_Method__getClass;
 
@@ -152,13 +152,13 @@ function generics_Box_quark_int__get_Method__init_fields__() {
 generics_Box_quark_int__get_Method.prototype.__init_fields__ = generics_Box_quark_int__get_Method__init_fields__;
 
 function generics_Box_quark_int__get_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.Box; });
     return (obj).get();
 }
 generics_Box_quark_int__get_Method.prototype.invoke = generics_Box_quark_int__get_Method_invoke;
 
 function generics_Box_quark_int__get_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_Box_quark_int__get_Method.prototype._getClass = generics_Box_quark_int__get_Method__getClass;
 
@@ -193,7 +193,7 @@ function generics_Box_quark_int__construct(args) {
 generics_Box_quark_int_.prototype.construct = generics_Box_quark_int__construct;
 
 function generics_Box_quark_int___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_Box_quark_int_.prototype._getClass = generics_Box_quark_int___getClass;
 
@@ -220,14 +220,14 @@ function generics_Crate_quark_Object__set_Method__init_fields__() {
 generics_Crate_quark_Object__set_Method.prototype.__init_fields__ = generics_Crate_quark_Object__set_Method__init_fields__;
 
 function generics_Crate_quark_Object__set_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.Crate; });
     (obj).set((args)[0]);
     return null;
 }
 generics_Crate_quark_Object__set_Method.prototype.invoke = generics_Crate_quark_Object__set_Method_invoke;
 
 function generics_Crate_quark_Object__set_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_Crate_quark_Object__set_Method.prototype._getClass = generics_Crate_quark_Object__set_Method__getClass;
 
@@ -253,13 +253,13 @@ function generics_Crate_quark_Object__get_Method__init_fields__() {
 generics_Crate_quark_Object__get_Method.prototype.__init_fields__ = generics_Crate_quark_Object__get_Method__init_fields__;
 
 function generics_Crate_quark_Object__get_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.Crate; });
     return (obj).get();
 }
 generics_Crate_quark_Object__get_Method.prototype.invoke = generics_Crate_quark_Object__get_Method_invoke;
 
 function generics_Crate_quark_Object__get_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_Crate_quark_Object__get_Method.prototype._getClass = generics_Crate_quark_Object__get_Method__getClass;
 
@@ -294,7 +294,7 @@ function generics_Crate_quark_Object__construct(args) {
 generics_Crate_quark_Object_.prototype.construct = generics_Crate_quark_Object__construct;
 
 function generics_Crate_quark_Object___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_Crate_quark_Object_.prototype._getClass = generics_Crate_quark_Object___getClass;
 
@@ -330,7 +330,7 @@ function generics_Sack_construct(args) {
 generics_Sack.prototype.construct = generics_Sack_construct;
 
 function generics_Sack__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_Sack.prototype._getClass = generics_Sack__getClass;
 
@@ -357,13 +357,13 @@ function generics_Matrix_quark_Object____get___Method__init_fields__() {
 generics_Matrix_quark_Object____get___Method.prototype.__init_fields__ = generics_Matrix_quark_Object____get___Method__init_fields__;
 
 function generics_Matrix_quark_Object____get___Method_invoke(object, args) {
-    var obj = object;
-    return (obj).__get__((args)[0], (args)[1]);
+    var obj = _qrt.cast(object, function () { return generics.Matrix; });
+    return (obj).__get__(_qrt.cast((args)[0], function () { return Number; }), _qrt.cast((args)[1], function () { return Number; }));
 }
 generics_Matrix_quark_Object____get___Method.prototype.invoke = generics_Matrix_quark_Object____get___Method_invoke;
 
 function generics_Matrix_quark_Object____get___Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_Matrix_quark_Object____get___Method.prototype._getClass = generics_Matrix_quark_Object____get___Method__getClass;
 
@@ -389,14 +389,14 @@ function generics_Matrix_quark_Object____set___Method__init_fields__() {
 generics_Matrix_quark_Object____set___Method.prototype.__init_fields__ = generics_Matrix_quark_Object____set___Method__init_fields__;
 
 function generics_Matrix_quark_Object____set___Method_invoke(object, args) {
-    var obj = object;
-    (obj).__set__((args)[0], (args)[1], (args)[2]);
+    var obj = _qrt.cast(object, function () { return generics.Matrix; });
+    (obj).__set__(_qrt.cast((args)[0], function () { return Number; }), _qrt.cast((args)[1], function () { return Number; }), (args)[2]);
     return null;
 }
 generics_Matrix_quark_Object____set___Method.prototype.invoke = generics_Matrix_quark_Object____set___Method_invoke;
 
 function generics_Matrix_quark_Object____set___Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_Matrix_quark_Object____set___Method.prototype._getClass = generics_Matrix_quark_Object____set___Method__getClass;
 
@@ -426,12 +426,12 @@ function generics_Matrix_quark_Object___init_fields__() {
 generics_Matrix_quark_Object_.prototype.__init_fields__ = generics_Matrix_quark_Object___init_fields__;
 generics_Matrix_quark_Object_.singleton = new generics_Matrix_quark_Object_();
 function generics_Matrix_quark_Object__construct(args) {
-    return new generics.Matrix((args)[0], (args)[1]);
+    return new generics.Matrix(_qrt.cast((args)[0], function () { return Number; }), _qrt.cast((args)[1], function () { return Number; }));
 }
 generics_Matrix_quark_Object_.prototype.construct = generics_Matrix_quark_Object__construct;
 
 function generics_Matrix_quark_Object___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_Matrix_quark_Object_.prototype._getClass = generics_Matrix_quark_Object___getClass;
 
@@ -458,13 +458,13 @@ function generics_constructors_Box_quark_Object__get_Method__init_fields__() {
 generics_constructors_Box_quark_Object__get_Method.prototype.__init_fields__ = generics_constructors_Box_quark_Object__get_Method__init_fields__;
 
 function generics_constructors_Box_quark_Object__get_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.constructors.Box; });
     return (obj).get();
 }
 generics_constructors_Box_quark_Object__get_Method.prototype.invoke = generics_constructors_Box_quark_Object__get_Method_invoke;
 
 function generics_constructors_Box_quark_Object__get_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_constructors_Box_quark_Object__get_Method.prototype._getClass = generics_constructors_Box_quark_Object__get_Method__getClass;
 
@@ -499,7 +499,7 @@ function generics_constructors_Box_quark_Object__construct(args) {
 generics_constructors_Box_quark_Object_.prototype.construct = generics_constructors_Box_quark_Object__construct;
 
 function generics_constructors_Box_quark_Object___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_constructors_Box_quark_Object_.prototype._getClass = generics_constructors_Box_quark_Object___getClass;
 
@@ -526,13 +526,13 @@ function generics_pkg_Foo_quark_Object__foo_Method__init_fields__() {
 generics_pkg_Foo_quark_Object__foo_Method.prototype.__init_fields__ = generics_pkg_Foo_quark_Object__foo_Method__init_fields__;
 
 function generics_pkg_Foo_quark_Object__foo_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.pkg.Foo; });
     return (obj).foo();
 }
 generics_pkg_Foo_quark_Object__foo_Method.prototype.invoke = generics_pkg_Foo_quark_Object__foo_Method_invoke;
 
 function generics_pkg_Foo_quark_Object__foo_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_pkg_Foo_quark_Object__foo_Method.prototype._getClass = generics_pkg_Foo_quark_Object__foo_Method__getClass;
 
@@ -558,13 +558,13 @@ function generics_pkg_Foo_quark_Object__get_Method__init_fields__() {
 generics_pkg_Foo_quark_Object__get_Method.prototype.__init_fields__ = generics_pkg_Foo_quark_Object__get_Method__init_fields__;
 
 function generics_pkg_Foo_quark_Object__get_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.pkg.Foo; });
     return (obj).get();
 }
 generics_pkg_Foo_quark_Object__get_Method.prototype.invoke = generics_pkg_Foo_quark_Object__get_Method_invoke;
 
 function generics_pkg_Foo_quark_Object__get_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_pkg_Foo_quark_Object__get_Method.prototype._getClass = generics_pkg_Foo_quark_Object__get_Method__getClass;
 
@@ -599,7 +599,7 @@ function generics_pkg_Foo_quark_Object__construct(args) {
 generics_pkg_Foo_quark_Object_.prototype.construct = generics_pkg_Foo_quark_Object__construct;
 
 function generics_pkg_Foo_quark_Object___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_pkg_Foo_quark_Object_.prototype._getClass = generics_pkg_Foo_quark_Object___getClass;
 
@@ -626,13 +626,13 @@ function generics_pkg_StringFoo_get_Method__init_fields__() {
 generics_pkg_StringFoo_get_Method.prototype.__init_fields__ = generics_pkg_StringFoo_get_Method__init_fields__;
 
 function generics_pkg_StringFoo_get_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.pkg.StringFoo; });
     return (obj).get();
 }
 generics_pkg_StringFoo_get_Method.prototype.invoke = generics_pkg_StringFoo_get_Method_invoke;
 
 function generics_pkg_StringFoo_get_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_pkg_StringFoo_get_Method.prototype._getClass = generics_pkg_StringFoo_get_Method__getClass;
 
@@ -658,13 +658,13 @@ function generics_pkg_StringFoo_foo_Method__init_fields__() {
 generics_pkg_StringFoo_foo_Method.prototype.__init_fields__ = generics_pkg_StringFoo_foo_Method__init_fields__;
 
 function generics_pkg_StringFoo_foo_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.pkg.StringFoo; });
     return (obj).foo();
 }
 generics_pkg_StringFoo_foo_Method.prototype.invoke = generics_pkg_StringFoo_foo_Method_invoke;
 
 function generics_pkg_StringFoo_foo_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_pkg_StringFoo_foo_Method.prototype._getClass = generics_pkg_StringFoo_foo_Method__getClass;
 
@@ -699,7 +699,7 @@ function generics_pkg_StringFoo_construct(args) {
 generics_pkg_StringFoo.prototype.construct = generics_pkg_StringFoo_construct;
 
 function generics_pkg_StringFoo__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_pkg_StringFoo.prototype._getClass = generics_pkg_StringFoo__getClass;
 
@@ -730,12 +730,12 @@ function generics_pkg_Box_quark_String___init_fields__() {
 generics_pkg_Box_quark_String_.prototype.__init_fields__ = generics_pkg_Box_quark_String___init_fields__;
 generics_pkg_Box_quark_String_.singleton = new generics_pkg_Box_quark_String_();
 function generics_pkg_Box_quark_String__construct(args) {
-    return new generics.pkg.Box((args)[0]);
+    return new generics.pkg.Box(_qrt.cast((args)[0], function () { return String; }));
 }
 generics_pkg_Box_quark_String_.prototype.construct = generics_pkg_Box_quark_String__construct;
 
 function generics_pkg_Box_quark_String___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_pkg_Box_quark_String_.prototype._getClass = generics_pkg_Box_quark_String___getClass;
 
@@ -766,12 +766,12 @@ function generics_pkg_StringBox__init_fields__() {
 generics_pkg_StringBox.prototype.__init_fields__ = generics_pkg_StringBox__init_fields__;
 generics_pkg_StringBox.singleton = new generics_pkg_StringBox();
 function generics_pkg_StringBox_construct(args) {
-    return new generics.pkg.StringBox((args)[0]);
+    return new generics.pkg.StringBox(_qrt.cast((args)[0], function () { return String; }));
 }
 generics_pkg_StringBox.prototype.construct = generics_pkg_StringBox_construct;
 
 function generics_pkg_StringBox__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_pkg_StringBox.prototype._getClass = generics_pkg_StringBox__getClass;
 
@@ -798,13 +798,13 @@ function generics_ccc_TLSContextInitializer_getValue_Method__init_fields__() {
 generics_ccc_TLSContextInitializer_getValue_Method.prototype.__init_fields__ = generics_ccc_TLSContextInitializer_getValue_Method__init_fields__;
 
 function generics_ccc_TLSContextInitializer_getValue_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.ccc.TLSContextInitializer; });
     return (obj).getValue();
 }
 generics_ccc_TLSContextInitializer_getValue_Method.prototype.invoke = generics_ccc_TLSContextInitializer_getValue_Method_invoke;
 
 function generics_ccc_TLSContextInitializer_getValue_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_ccc_TLSContextInitializer_getValue_Method.prototype._getClass = generics_ccc_TLSContextInitializer_getValue_Method__getClass;
 
@@ -839,7 +839,7 @@ function generics_ccc_TLSContextInitializer_construct(args) {
 generics_ccc_TLSContextInitializer.prototype.construct = generics_ccc_TLSContextInitializer_construct;
 
 function generics_ccc_TLSContextInitializer__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_ccc_TLSContextInitializer.prototype._getClass = generics_ccc_TLSContextInitializer__getClass;
 
@@ -866,13 +866,13 @@ function generics_ccc_Context_current_Method__init_fields__() {
 generics_ccc_Context_current_Method.prototype.__init_fields__ = generics_ccc_Context_current_Method__init_fields__;
 
 function generics_ccc_Context_current_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.ccc.Context; });
     return generics.ccc.Context.current();
 }
 generics_ccc_Context_current_Method.prototype.invoke = generics_ccc_Context_current_Method_invoke;
 
 function generics_ccc_Context_current_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_ccc_Context_current_Method.prototype._getClass = generics_ccc_Context_current_Method__getClass;
 
@@ -898,13 +898,13 @@ function generics_ccc_Context_global_Method__init_fields__() {
 generics_ccc_Context_global_Method.prototype.__init_fields__ = generics_ccc_Context_global_Method__init_fields__;
 
 function generics_ccc_Context_global_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.ccc.Context; });
     return generics.ccc.Context.global();
 }
 generics_ccc_Context_global_Method.prototype.invoke = generics_ccc_Context_global_Method_invoke;
 
 function generics_ccc_Context_global_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_ccc_Context_global_Method.prototype._getClass = generics_ccc_Context_global_Method__getClass;
 
@@ -934,12 +934,12 @@ function generics_ccc_Context__init_fields__() {
 generics_ccc_Context.prototype.__init_fields__ = generics_ccc_Context__init_fields__;
 generics_ccc_Context.singleton = new generics_ccc_Context();
 function generics_ccc_Context_construct(args) {
-    return new generics.ccc.Context((args)[0]);
+    return new generics.ccc.Context(_qrt.cast((args)[0], function () { return generics.ccc.Context; }));
 }
 generics_ccc_Context.prototype.construct = generics_ccc_Context_construct;
 
 function generics_ccc_Context__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_ccc_Context.prototype._getClass = generics_ccc_Context__getClass;
 
@@ -966,13 +966,13 @@ function generics_ccc_TLSInitializer_quark_Object__getValue_Method__init_fields_
 generics_ccc_TLSInitializer_quark_Object__getValue_Method.prototype.__init_fields__ = generics_ccc_TLSInitializer_quark_Object__getValue_Method__init_fields__;
 
 function generics_ccc_TLSInitializer_quark_Object__getValue_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.ccc.TLSInitializer; });
     return (obj).getValue();
 }
 generics_ccc_TLSInitializer_quark_Object__getValue_Method.prototype.invoke = generics_ccc_TLSInitializer_quark_Object__getValue_Method_invoke;
 
 function generics_ccc_TLSInitializer_quark_Object__getValue_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_ccc_TLSInitializer_quark_Object__getValue_Method.prototype._getClass = generics_ccc_TLSInitializer_quark_Object__getValue_Method__getClass;
 
@@ -1007,7 +1007,7 @@ function generics_ccc_TLSInitializer_quark_Object__construct(args) {
 generics_ccc_TLSInitializer_quark_Object_.prototype.construct = generics_ccc_TLSInitializer_quark_Object__construct;
 
 function generics_ccc_TLSInitializer_quark_Object___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_ccc_TLSInitializer_quark_Object_.prototype._getClass = generics_ccc_TLSInitializer_quark_Object___getClass;
 
@@ -1034,13 +1034,13 @@ function generics_ccc_TLS_generics_ccc_Context__getValue_Method__init_fields__()
 generics_ccc_TLS_generics_ccc_Context__getValue_Method.prototype.__init_fields__ = generics_ccc_TLS_generics_ccc_Context__getValue_Method__init_fields__;
 
 function generics_ccc_TLS_generics_ccc_Context__getValue_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return generics.ccc.TLS; });
     return (obj).getValue();
 }
 generics_ccc_TLS_generics_ccc_Context__getValue_Method.prototype.invoke = generics_ccc_TLS_generics_ccc_Context__getValue_Method_invoke;
 
 function generics_ccc_TLS_generics_ccc_Context__getValue_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_ccc_TLS_generics_ccc_Context__getValue_Method.prototype._getClass = generics_ccc_TLS_generics_ccc_Context__getValue_Method__getClass;
 
@@ -1070,12 +1070,12 @@ function generics_ccc_TLS_generics_ccc_Context___init_fields__() {
 generics_ccc_TLS_generics_ccc_Context_.prototype.__init_fields__ = generics_ccc_TLS_generics_ccc_Context___init_fields__;
 generics_ccc_TLS_generics_ccc_Context_.singleton = new generics_ccc_TLS_generics_ccc_Context_();
 function generics_ccc_TLS_generics_ccc_Context__construct(args) {
-    return new generics.ccc.TLS((args)[0]);
+    return new generics.ccc.TLS(_qrt.cast((args)[0], function () { return generics.ccc.TLSInitializer; }));
 }
 generics_ccc_TLS_generics_ccc_Context_.prototype.construct = generics_ccc_TLS_generics_ccc_Context__construct;
 
 function generics_ccc_TLS_generics_ccc_Context___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 generics_ccc_TLS_generics_ccc_Context_.prototype._getClass = generics_ccc_TLS_generics_ccc_Context___getClass;
 
@@ -1111,7 +1111,7 @@ function inheritance_Base_construct(args) {
 inheritance_Base.prototype.construct = inheritance_Base_construct;
 
 function inheritance_Base__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_Base.prototype._getClass = inheritance_Base__getClass;
 
@@ -1147,7 +1147,7 @@ function inheritance_Test_construct(args) {
 inheritance_Test.prototype.construct = inheritance_Test_construct;
 
 function inheritance_Test__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_Test.prototype._getClass = inheritance_Test__getClass;
 
@@ -1178,12 +1178,12 @@ function inheritance_A__init_fields__() {
 inheritance_A.prototype.__init_fields__ = inheritance_A__init_fields__;
 inheritance_A.singleton = new inheritance_A();
 function inheritance_A_construct(args) {
-    return new inheritance.A((args)[0]);
+    return new inheritance.A(_qrt.cast((args)[0], function () { return String; }));
 }
 inheritance_A.prototype.construct = inheritance_A_construct;
 
 function inheritance_A__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_A.prototype._getClass = inheritance_A__getClass;
 
@@ -1210,14 +1210,14 @@ function inheritance_B_greet_Method__init_fields__() {
 inheritance_B_greet_Method.prototype.__init_fields__ = inheritance_B_greet_Method__init_fields__;
 
 function inheritance_B_greet_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.B; });
     (obj).greet();
     return null;
 }
 inheritance_B_greet_Method.prototype.invoke = inheritance_B_greet_Method_invoke;
 
 function inheritance_B_greet_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_B_greet_Method.prototype._getClass = inheritance_B_greet_Method__getClass;
 
@@ -1247,12 +1247,12 @@ function inheritance_B__init_fields__() {
 inheritance_B.prototype.__init_fields__ = inheritance_B__init_fields__;
 inheritance_B.singleton = new inheritance_B();
 function inheritance_B_construct(args) {
-    return new inheritance.B((args)[0]);
+    return new inheritance.B(_qrt.cast((args)[0], function () { return String; }));
 }
 inheritance_B.prototype.construct = inheritance_B_construct;
 
 function inheritance_B__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_B.prototype._getClass = inheritance_B__getClass;
 
@@ -1279,14 +1279,14 @@ function inheritance_C_greet_Method__init_fields__() {
 inheritance_C_greet_Method.prototype.__init_fields__ = inheritance_C_greet_Method__init_fields__;
 
 function inheritance_C_greet_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.C; });
     (obj).greet();
     return null;
 }
 inheritance_C_greet_Method.prototype.invoke = inheritance_C_greet_Method_invoke;
 
 function inheritance_C_greet_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_C_greet_Method.prototype._getClass = inheritance_C_greet_Method__getClass;
 
@@ -1316,12 +1316,12 @@ function inheritance_C__init_fields__() {
 inheritance_C.prototype.__init_fields__ = inheritance_C__init_fields__;
 inheritance_C.singleton = new inheritance_C();
 function inheritance_C_construct(args) {
-    return new inheritance.C((args)[0]);
+    return new inheritance.C(_qrt.cast((args)[0], function () { return String; }));
 }
 inheritance_C.prototype.construct = inheritance_C_construct;
 
 function inheritance_C__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_C.prototype._getClass = inheritance_C__getClass;
 
@@ -1357,7 +1357,7 @@ function inheritance_X_construct(args) {
 inheritance_X.prototype.construct = inheritance_X_construct;
 
 function inheritance_X__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_X.prototype._getClass = inheritance_X__getClass;
 
@@ -1384,14 +1384,14 @@ function inheritance_Y_test_Method__init_fields__() {
 inheritance_Y_test_Method.prototype.__init_fields__ = inheritance_Y_test_Method__init_fields__;
 
 function inheritance_Y_test_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.Y; });
     (obj).test();
     return null;
 }
 inheritance_Y_test_Method.prototype.invoke = inheritance_Y_test_Method_invoke;
 
 function inheritance_Y_test_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_Y_test_Method.prototype._getClass = inheritance_Y_test_Method__getClass;
 
@@ -1421,12 +1421,12 @@ function inheritance_Y__init_fields__() {
 inheritance_Y.prototype.__init_fields__ = inheritance_Y__init_fields__;
 inheritance_Y.singleton = new inheritance_Y();
 function inheritance_Y_construct(args) {
-    return new inheritance.Y((args)[0]);
+    return new inheritance.Y(_qrt.cast((args)[0], function () { return String; }));
 }
 inheritance_Y.prototype.construct = inheritance_Y_construct;
 
 function inheritance_Y__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_Y.prototype._getClass = inheritance_Y__getClass;
 
@@ -1453,14 +1453,14 @@ function inheritance_t1_A_foo_Method__init_fields__() {
 inheritance_t1_A_foo_Method.prototype.__init_fields__ = inheritance_t1_A_foo_Method__init_fields__;
 
 function inheritance_t1_A_foo_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.t1.A; });
     (obj).foo();
     return null;
 }
 inheritance_t1_A_foo_Method.prototype.invoke = inheritance_t1_A_foo_Method_invoke;
 
 function inheritance_t1_A_foo_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_t1_A_foo_Method.prototype._getClass = inheritance_t1_A_foo_Method__getClass;
 
@@ -1495,7 +1495,7 @@ function inheritance_t1_A_construct(args) {
 inheritance_t1_A.prototype.construct = inheritance_t1_A_construct;
 
 function inheritance_t1_A__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_t1_A.prototype._getClass = inheritance_t1_A__getClass;
 
@@ -1522,14 +1522,14 @@ function inheritance_t1_B_foo_Method__init_fields__() {
 inheritance_t1_B_foo_Method.prototype.__init_fields__ = inheritance_t1_B_foo_Method__init_fields__;
 
 function inheritance_t1_B_foo_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.t1.B; });
     (obj).foo();
     return null;
 }
 inheritance_t1_B_foo_Method.prototype.invoke = inheritance_t1_B_foo_Method_invoke;
 
 function inheritance_t1_B_foo_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_t1_B_foo_Method.prototype._getClass = inheritance_t1_B_foo_Method__getClass;
 
@@ -1564,7 +1564,7 @@ function inheritance_t1_B_construct(args) {
 inheritance_t1_B.prototype.construct = inheritance_t1_B_construct;
 
 function inheritance_t1_B__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_t1_B.prototype._getClass = inheritance_t1_B__getClass;
 
@@ -1591,14 +1591,14 @@ function inheritance_t1_C_foo_Method__init_fields__() {
 inheritance_t1_C_foo_Method.prototype.__init_fields__ = inheritance_t1_C_foo_Method__init_fields__;
 
 function inheritance_t1_C_foo_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.t1.C; });
     (obj).foo();
     return null;
 }
 inheritance_t1_C_foo_Method.prototype.invoke = inheritance_t1_C_foo_Method_invoke;
 
 function inheritance_t1_C_foo_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_t1_C_foo_Method.prototype._getClass = inheritance_t1_C_foo_Method__getClass;
 
@@ -1633,7 +1633,7 @@ function inheritance_t1_C_construct(args) {
 inheritance_t1_C.prototype.construct = inheritance_t1_C_construct;
 
 function inheritance_t1_C__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_t1_C.prototype._getClass = inheritance_t1_C__getClass;
 
@@ -1669,7 +1669,7 @@ function inheritance_t2_A_construct(args) {
 inheritance_t2_A.prototype.construct = inheritance_t2_A_construct;
 
 function inheritance_t2_A__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_t2_A.prototype._getClass = inheritance_t2_A__getClass;
 
@@ -1705,7 +1705,7 @@ function inheritance_t2_B_construct(args) {
 inheritance_t2_B.prototype.construct = inheritance_t2_B_construct;
 
 function inheritance_t2_B__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_t2_B.prototype._getClass = inheritance_t2_B__getClass;
 
@@ -1741,7 +1741,7 @@ function inheritance_t2_X_quark_int__construct(args) {
 inheritance_t2_X_quark_int_.prototype.construct = inheritance_t2_X_quark_int__construct;
 
 function inheritance_t2_X_quark_int___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_t2_X_quark_int_.prototype._getClass = inheritance_t2_X_quark_int___getClass;
 
@@ -1777,7 +1777,7 @@ function inheritance_t2_Y_construct(args) {
 inheritance_t2_Y.prototype.construct = inheritance_t2_Y_construct;
 
 function inheritance_t2_Y__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_t2_Y.prototype._getClass = inheritance_t2_Y__getClass;
 
@@ -1804,14 +1804,14 @@ function inheritance_pets_Cat_greet_Method__init_fields__() {
 inheritance_pets_Cat_greet_Method.prototype.__init_fields__ = inheritance_pets_Cat_greet_Method__init_fields__;
 
 function inheritance_pets_Cat_greet_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.pets.Cat; });
     (obj).greet();
     return null;
 }
 inheritance_pets_Cat_greet_Method.prototype.invoke = inheritance_pets_Cat_greet_Method_invoke;
 
 function inheritance_pets_Cat_greet_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_pets_Cat_greet_Method.prototype._getClass = inheritance_pets_Cat_greet_Method__getClass;
 
@@ -1846,7 +1846,7 @@ function inheritance_pets_Cat_construct(args) {
 inheritance_pets_Cat.prototype.construct = inheritance_pets_Cat_construct;
 
 function inheritance_pets_Cat__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_pets_Cat.prototype._getClass = inheritance_pets_Cat__getClass;
 
@@ -1873,14 +1873,14 @@ function inheritance_pets_Dog_greet_Method__init_fields__() {
 inheritance_pets_Dog_greet_Method.prototype.__init_fields__ = inheritance_pets_Dog_greet_Method__init_fields__;
 
 function inheritance_pets_Dog_greet_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.pets.Dog; });
     (obj).greet();
     return null;
 }
 inheritance_pets_Dog_greet_Method.prototype.invoke = inheritance_pets_Dog_greet_Method_invoke;
 
 function inheritance_pets_Dog_greet_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_pets_Dog_greet_Method.prototype._getClass = inheritance_pets_Dog_greet_Method__getClass;
 
@@ -1915,7 +1915,7 @@ function inheritance_pets_Dog_construct(args) {
 inheritance_pets_Dog.prototype.construct = inheritance_pets_Dog_construct;
 
 function inheritance_pets_Dog__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_pets_Dog.prototype._getClass = inheritance_pets_Dog__getClass;
 
@@ -1942,13 +1942,13 @@ function inheritance_Message_encode_Method__init_fields__() {
 inheritance_Message_encode_Method.prototype.__init_fields__ = inheritance_Message_encode_Method__init_fields__;
 
 function inheritance_Message_encode_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.Message; });
     return (obj).encode();
 }
 inheritance_Message_encode_Method.prototype.invoke = inheritance_Message_encode_Method_invoke;
 
 function inheritance_Message_encode_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_Message_encode_Method.prototype._getClass = inheritance_Message_encode_Method__getClass;
 
@@ -1983,7 +1983,7 @@ function inheritance_Message_construct(args) {
 inheritance_Message.prototype.construct = inheritance_Message_construct;
 
 function inheritance_Message__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_Message.prototype._getClass = inheritance_Message__getClass;
 
@@ -2010,13 +2010,13 @@ function inheritance_Ping_encode_Method__init_fields__() {
 inheritance_Ping_encode_Method.prototype.__init_fields__ = inheritance_Ping_encode_Method__init_fields__;
 
 function inheritance_Ping_encode_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.Ping; });
     return (obj).encode();
 }
 inheritance_Ping_encode_Method.prototype.invoke = inheritance_Ping_encode_Method_invoke;
 
 function inheritance_Ping_encode_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_Ping_encode_Method.prototype._getClass = inheritance_Ping_encode_Method__getClass;
 
@@ -2051,7 +2051,7 @@ function inheritance_Ping_construct(args) {
 inheritance_Ping.prototype.construct = inheritance_Ping_construct;
 
 function inheritance_Ping__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_Ping.prototype._getClass = inheritance_Ping__getClass;
 
@@ -2078,13 +2078,13 @@ function inheritance_Pong_toString_Method__init_fields__() {
 inheritance_Pong_toString_Method.prototype.__init_fields__ = inheritance_Pong_toString_Method__init_fields__;
 
 function inheritance_Pong_toString_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.Pong; });
     return (obj).toString();
 }
 inheritance_Pong_toString_Method.prototype.invoke = inheritance_Pong_toString_Method_invoke;
 
 function inheritance_Pong_toString_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_Pong_toString_Method.prototype._getClass = inheritance_Pong_toString_Method__getClass;
 
@@ -2110,13 +2110,13 @@ function inheritance_Pong_encode_Method__init_fields__() {
 inheritance_Pong_encode_Method.prototype.__init_fields__ = inheritance_Pong_encode_Method__init_fields__;
 
 function inheritance_Pong_encode_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.Pong; });
     return (obj).encode();
 }
 inheritance_Pong_encode_Method.prototype.invoke = inheritance_Pong_encode_Method_invoke;
 
 function inheritance_Pong_encode_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_Pong_encode_Method.prototype._getClass = inheritance_Pong_encode_Method__getClass;
 
@@ -2151,7 +2151,7 @@ function inheritance_Pong_construct(args) {
 inheritance_Pong.prototype.construct = inheritance_Pong_construct;
 
 function inheritance_Pong__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_Pong.prototype._getClass = inheritance_Pong__getClass;
 
@@ -2178,14 +2178,14 @@ function inheritance_super__A_greet_Method__init_fields__() {
 inheritance_super__A_greet_Method.prototype.__init_fields__ = inheritance_super__A_greet_Method__init_fields__;
 
 function inheritance_super__A_greet_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.super_.A; });
     (obj).greet();
     return null;
 }
 inheritance_super__A_greet_Method.prototype.invoke = inheritance_super__A_greet_Method_invoke;
 
 function inheritance_super__A_greet_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_super__A_greet_Method.prototype._getClass = inheritance_super__A_greet_Method__getClass;
 
@@ -2215,12 +2215,12 @@ function inheritance_super__A__init_fields__() {
 inheritance_super__A.prototype.__init_fields__ = inheritance_super__A__init_fields__;
 inheritance_super__A.singleton = new inheritance_super__A();
 function inheritance_super__A_construct(args) {
-    return new inheritance.super_.A((args)[0]);
+    return new inheritance.super_.A(_qrt.cast((args)[0], function () { return String; }));
 }
 inheritance_super__A.prototype.construct = inheritance_super__A_construct;
 
 function inheritance_super__A__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_super__A.prototype._getClass = inheritance_super__A__getClass;
 
@@ -2247,14 +2247,14 @@ function inheritance_super__B_greet_Method__init_fields__() {
 inheritance_super__B_greet_Method.prototype.__init_fields__ = inheritance_super__B_greet_Method__init_fields__;
 
 function inheritance_super__B_greet_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.super_.B; });
     (obj).greet();
     return null;
 }
 inheritance_super__B_greet_Method.prototype.invoke = inheritance_super__B_greet_Method_invoke;
 
 function inheritance_super__B_greet_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_super__B_greet_Method.prototype._getClass = inheritance_super__B_greet_Method__getClass;
 
@@ -2289,7 +2289,7 @@ function inheritance_super__B_construct(args) {
 inheritance_super__B.prototype.construct = inheritance_super__B_construct;
 
 function inheritance_super__B__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_super__B.prototype._getClass = inheritance_super__B__getClass;
 
@@ -2316,14 +2316,14 @@ function inheritance_use_before_def_Bar_go_Method__init_fields__() {
 inheritance_use_before_def_Bar_go_Method.prototype.__init_fields__ = inheritance_use_before_def_Bar_go_Method__init_fields__;
 
 function inheritance_use_before_def_Bar_go_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return inheritance.use_before_def.Bar; });
     (obj).go();
     return null;
 }
 inheritance_use_before_def_Bar_go_Method.prototype.invoke = inheritance_use_before_def_Bar_go_Method_invoke;
 
 function inheritance_use_before_def_Bar_go_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_use_before_def_Bar_go_Method.prototype._getClass = inheritance_use_before_def_Bar_go_Method__getClass;
 
@@ -2358,7 +2358,7 @@ function inheritance_use_before_def_Bar_construct(args) {
 inheritance_use_before_def_Bar.prototype.construct = inheritance_use_before_def_Bar_construct;
 
 function inheritance_use_before_def_Bar__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_use_before_def_Bar.prototype._getClass = inheritance_use_before_def_Bar__getClass;
 
@@ -2394,7 +2394,7 @@ function inheritance_use_before_def_Foo_construct(args) {
 inheritance_use_before_def_Foo.prototype.construct = inheritance_use_before_def_Foo_construct;
 
 function inheritance_use_before_def_Foo__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 inheritance_use_before_def_Foo.prototype._getClass = inheritance_use_before_def_Foo__getClass;
 
@@ -2421,14 +2421,14 @@ function interfaces_A_foo_Method__init_fields__() {
 interfaces_A_foo_Method.prototype.__init_fields__ = interfaces_A_foo_Method__init_fields__;
 
 function interfaces_A_foo_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.A; });
     (obj).foo();
     return null;
 }
 interfaces_A_foo_Method.prototype.invoke = interfaces_A_foo_Method_invoke;
 
 function interfaces_A_foo_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_A_foo_Method.prototype._getClass = interfaces_A_foo_Method__getClass;
 
@@ -2454,14 +2454,14 @@ function interfaces_A_bar_Method__init_fields__() {
 interfaces_A_bar_Method.prototype.__init_fields__ = interfaces_A_bar_Method__init_fields__;
 
 function interfaces_A_bar_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.A; });
     (obj).bar();
     return null;
 }
 interfaces_A_bar_Method.prototype.invoke = interfaces_A_bar_Method_invoke;
 
 function interfaces_A_bar_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_A_bar_Method.prototype._getClass = interfaces_A_bar_Method__getClass;
 
@@ -2496,7 +2496,7 @@ function interfaces_A_construct(args) {
 interfaces_A.prototype.construct = interfaces_A_construct;
 
 function interfaces_A__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_A.prototype._getClass = interfaces_A__getClass;
 
@@ -2523,14 +2523,14 @@ function interfaces_B_bar_Method__init_fields__() {
 interfaces_B_bar_Method.prototype.__init_fields__ = interfaces_B_bar_Method__init_fields__;
 
 function interfaces_B_bar_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.B; });
     (obj).bar();
     return null;
 }
 interfaces_B_bar_Method.prototype.invoke = interfaces_B_bar_Method_invoke;
 
 function interfaces_B_bar_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_B_bar_Method.prototype._getClass = interfaces_B_bar_Method__getClass;
 
@@ -2565,7 +2565,7 @@ function interfaces_B_construct(args) {
 interfaces_B.prototype.construct = interfaces_B_construct;
 
 function interfaces_B__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_B.prototype._getClass = interfaces_B__getClass;
 
@@ -2592,14 +2592,14 @@ function interfaces_C_foo_Method__init_fields__() {
 interfaces_C_foo_Method.prototype.__init_fields__ = interfaces_C_foo_Method__init_fields__;
 
 function interfaces_C_foo_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.C; });
     (obj).foo();
     return null;
 }
 interfaces_C_foo_Method.prototype.invoke = interfaces_C_foo_Method_invoke;
 
 function interfaces_C_foo_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_C_foo_Method.prototype._getClass = interfaces_C_foo_Method__getClass;
 
@@ -2634,7 +2634,7 @@ function interfaces_C_construct(args) {
 interfaces_C.prototype.construct = interfaces_C_construct;
 
 function interfaces_C__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_C.prototype._getClass = interfaces_C__getClass;
 
@@ -2661,14 +2661,14 @@ function interfaces_T1_foo_Method__init_fields__() {
 interfaces_T1_foo_Method.prototype.__init_fields__ = interfaces_T1_foo_Method__init_fields__;
 
 function interfaces_T1_foo_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.T1; });
     (obj).foo();
     return null;
 }
 interfaces_T1_foo_Method.prototype.invoke = interfaces_T1_foo_Method_invoke;
 
 function interfaces_T1_foo_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T1_foo_Method.prototype._getClass = interfaces_T1_foo_Method__getClass;
 
@@ -2694,14 +2694,14 @@ function interfaces_T1_bar_Method__init_fields__() {
 interfaces_T1_bar_Method.prototype.__init_fields__ = interfaces_T1_bar_Method__init_fields__;
 
 function interfaces_T1_bar_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.T1; });
     (obj).bar();
     return null;
 }
 interfaces_T1_bar_Method.prototype.invoke = interfaces_T1_bar_Method_invoke;
 
 function interfaces_T1_bar_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T1_bar_Method.prototype._getClass = interfaces_T1_bar_Method__getClass;
 
@@ -2736,7 +2736,7 @@ function interfaces_T1_construct(args) {
 interfaces_T1.prototype.construct = interfaces_T1_construct;
 
 function interfaces_T1__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T1.prototype._getClass = interfaces_T1__getClass;
 
@@ -2763,14 +2763,14 @@ function interfaces_T2_foo_Method__init_fields__() {
 interfaces_T2_foo_Method.prototype.__init_fields__ = interfaces_T2_foo_Method__init_fields__;
 
 function interfaces_T2_foo_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.T2; });
     (obj).foo();
     return null;
 }
 interfaces_T2_foo_Method.prototype.invoke = interfaces_T2_foo_Method_invoke;
 
 function interfaces_T2_foo_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T2_foo_Method.prototype._getClass = interfaces_T2_foo_Method__getClass;
 
@@ -2796,14 +2796,14 @@ function interfaces_T2_bar_Method__init_fields__() {
 interfaces_T2_bar_Method.prototype.__init_fields__ = interfaces_T2_bar_Method__init_fields__;
 
 function interfaces_T2_bar_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.T2; });
     (obj).bar();
     return null;
 }
 interfaces_T2_bar_Method.prototype.invoke = interfaces_T2_bar_Method_invoke;
 
 function interfaces_T2_bar_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T2_bar_Method.prototype._getClass = interfaces_T2_bar_Method__getClass;
 
@@ -2838,7 +2838,7 @@ function interfaces_T2_construct(args) {
 interfaces_T2.prototype.construct = interfaces_T2_construct;
 
 function interfaces_T2__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T2.prototype._getClass = interfaces_T2__getClass;
 
@@ -2865,14 +2865,14 @@ function interfaces_T3_foo_Method__init_fields__() {
 interfaces_T3_foo_Method.prototype.__init_fields__ = interfaces_T3_foo_Method__init_fields__;
 
 function interfaces_T3_foo_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.T3; });
     (obj).foo();
     return null;
 }
 interfaces_T3_foo_Method.prototype.invoke = interfaces_T3_foo_Method_invoke;
 
 function interfaces_T3_foo_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T3_foo_Method.prototype._getClass = interfaces_T3_foo_Method__getClass;
 
@@ -2898,14 +2898,14 @@ function interfaces_T3_bar_Method__init_fields__() {
 interfaces_T3_bar_Method.prototype.__init_fields__ = interfaces_T3_bar_Method__init_fields__;
 
 function interfaces_T3_bar_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.T3; });
     (obj).bar();
     return null;
 }
 interfaces_T3_bar_Method.prototype.invoke = interfaces_T3_bar_Method_invoke;
 
 function interfaces_T3_bar_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T3_bar_Method.prototype._getClass = interfaces_T3_bar_Method__getClass;
 
@@ -2940,7 +2940,7 @@ function interfaces_T3_construct(args) {
 interfaces_T3.prototype.construct = interfaces_T3_construct;
 
 function interfaces_T3__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T3.prototype._getClass = interfaces_T3__getClass;
 
@@ -2967,14 +2967,14 @@ function interfaces_T4_foo_Method__init_fields__() {
 interfaces_T4_foo_Method.prototype.__init_fields__ = interfaces_T4_foo_Method__init_fields__;
 
 function interfaces_T4_foo_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.T4; });
     (obj).foo();
     return null;
 }
 interfaces_T4_foo_Method.prototype.invoke = interfaces_T4_foo_Method_invoke;
 
 function interfaces_T4_foo_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T4_foo_Method.prototype._getClass = interfaces_T4_foo_Method__getClass;
 
@@ -3000,14 +3000,14 @@ function interfaces_T4_bar_Method__init_fields__() {
 interfaces_T4_bar_Method.prototype.__init_fields__ = interfaces_T4_bar_Method__init_fields__;
 
 function interfaces_T4_bar_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.T4; });
     (obj).bar();
     return null;
 }
 interfaces_T4_bar_Method.prototype.invoke = interfaces_T4_bar_Method_invoke;
 
 function interfaces_T4_bar_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T4_bar_Method.prototype._getClass = interfaces_T4_bar_Method__getClass;
 
@@ -3042,7 +3042,7 @@ function interfaces_T4_construct(args) {
 interfaces_T4.prototype.construct = interfaces_T4_construct;
 
 function interfaces_T4__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T4.prototype._getClass = interfaces_T4__getClass;
 
@@ -3069,14 +3069,14 @@ function interfaces_T5_foo_Method__init_fields__() {
 interfaces_T5_foo_Method.prototype.__init_fields__ = interfaces_T5_foo_Method__init_fields__;
 
 function interfaces_T5_foo_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.T5; });
     (obj).foo();
     return null;
 }
 interfaces_T5_foo_Method.prototype.invoke = interfaces_T5_foo_Method_invoke;
 
 function interfaces_T5_foo_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T5_foo_Method.prototype._getClass = interfaces_T5_foo_Method__getClass;
 
@@ -3102,14 +3102,14 @@ function interfaces_T5_bar_Method__init_fields__() {
 interfaces_T5_bar_Method.prototype.__init_fields__ = interfaces_T5_bar_Method__init_fields__;
 
 function interfaces_T5_bar_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.T5; });
     (obj).bar();
     return null;
 }
 interfaces_T5_bar_Method.prototype.invoke = interfaces_T5_bar_Method_invoke;
 
 function interfaces_T5_bar_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T5_bar_Method.prototype._getClass = interfaces_T5_bar_Method__getClass;
 
@@ -3144,7 +3144,7 @@ function interfaces_T5_construct(args) {
 interfaces_T5.prototype.construct = interfaces_T5_construct;
 
 function interfaces_T5__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_T5.prototype._getClass = interfaces_T5__getClass;
 
@@ -3171,14 +3171,14 @@ function interfaces_Foo_m1_Method__init_fields__() {
 interfaces_Foo_m1_Method.prototype.__init_fields__ = interfaces_Foo_m1_Method__init_fields__;
 
 function interfaces_Foo_m1_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.Foo; });
     (obj).m1();
     return null;
 }
 interfaces_Foo_m1_Method.prototype.invoke = interfaces_Foo_m1_Method_invoke;
 
 function interfaces_Foo_m1_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_Foo_m1_Method.prototype._getClass = interfaces_Foo_m1_Method__getClass;
 
@@ -3204,14 +3204,14 @@ function interfaces_Foo_m2_Method__init_fields__() {
 interfaces_Foo_m2_Method.prototype.__init_fields__ = interfaces_Foo_m2_Method__init_fields__;
 
 function interfaces_Foo_m2_Method_invoke(object, args) {
-    var obj = object;
-    (obj).m2((args)[0]);
+    var obj = _qrt.cast(object, function () { return interfaces.Foo; });
+    (obj).m2(_qrt.cast((args)[0], function () { return Number; }));
     return null;
 }
 interfaces_Foo_m2_Method.prototype.invoke = interfaces_Foo_m2_Method_invoke;
 
 function interfaces_Foo_m2_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_Foo_m2_Method.prototype._getClass = interfaces_Foo_m2_Method__getClass;
 
@@ -3237,14 +3237,14 @@ function interfaces_Foo_m3_Method__init_fields__() {
 interfaces_Foo_m3_Method.prototype.__init_fields__ = interfaces_Foo_m3_Method__init_fields__;
 
 function interfaces_Foo_m3_Method_invoke(object, args) {
-    var obj = object;
-    (obj).m3((args)[0]);
+    var obj = _qrt.cast(object, function () { return interfaces.Foo; });
+    (obj).m3(_qrt.cast((args)[0], function () { return Array; }));
     return null;
 }
 interfaces_Foo_m3_Method.prototype.invoke = interfaces_Foo_m3_Method_invoke;
 
 function interfaces_Foo_m3_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_Foo_m3_Method.prototype._getClass = interfaces_Foo_m3_Method__getClass;
 
@@ -3279,7 +3279,7 @@ function interfaces_Foo_construct(args) {
 interfaces_Foo.prototype.construct = interfaces_Foo_construct;
 
 function interfaces_Foo__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_Foo.prototype._getClass = interfaces_Foo__getClass;
 
@@ -3306,14 +3306,14 @@ function interfaces_Bar_quark_Object__m1_Method__init_fields__() {
 interfaces_Bar_quark_Object__m1_Method.prototype.__init_fields__ = interfaces_Bar_quark_Object__m1_Method__init_fields__;
 
 function interfaces_Bar_quark_Object__m1_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.Bar; });
     (obj).m1();
     return null;
 }
 interfaces_Bar_quark_Object__m1_Method.prototype.invoke = interfaces_Bar_quark_Object__m1_Method_invoke;
 
 function interfaces_Bar_quark_Object__m1_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_Bar_quark_Object__m1_Method.prototype._getClass = interfaces_Bar_quark_Object__m1_Method__getClass;
 
@@ -3339,14 +3339,14 @@ function interfaces_Bar_quark_Object__m2_Method__init_fields__() {
 interfaces_Bar_quark_Object__m2_Method.prototype.__init_fields__ = interfaces_Bar_quark_Object__m2_Method__init_fields__;
 
 function interfaces_Bar_quark_Object__m2_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.Bar; });
     (obj).m2((args)[0]);
     return null;
 }
 interfaces_Bar_quark_Object__m2_Method.prototype.invoke = interfaces_Bar_quark_Object__m2_Method_invoke;
 
 function interfaces_Bar_quark_Object__m2_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_Bar_quark_Object__m2_Method.prototype._getClass = interfaces_Bar_quark_Object__m2_Method__getClass;
 
@@ -3372,14 +3372,14 @@ function interfaces_Bar_quark_Object__m3_Method__init_fields__() {
 interfaces_Bar_quark_Object__m3_Method.prototype.__init_fields__ = interfaces_Bar_quark_Object__m3_Method__init_fields__;
 
 function interfaces_Bar_quark_Object__m3_Method_invoke(object, args) {
-    var obj = object;
-    (obj).m3((args)[0]);
+    var obj = _qrt.cast(object, function () { return interfaces.Bar; });
+    (obj).m3(_qrt.cast((args)[0], function () { return Array; }));
     return null;
 }
 interfaces_Bar_quark_Object__m3_Method.prototype.invoke = interfaces_Bar_quark_Object__m3_Method_invoke;
 
 function interfaces_Bar_quark_Object__m3_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_Bar_quark_Object__m3_Method.prototype._getClass = interfaces_Bar_quark_Object__m3_Method__getClass;
 
@@ -3414,7 +3414,7 @@ function interfaces_Bar_quark_Object__construct(args) {
 interfaces_Bar_quark_Object_.prototype.construct = interfaces_Bar_quark_Object__construct;
 
 function interfaces_Bar_quark_Object___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_Bar_quark_Object_.prototype._getClass = interfaces_Bar_quark_Object___getClass;
 
@@ -3441,14 +3441,14 @@ function interfaces_Baz_m2_Method__init_fields__() {
 interfaces_Baz_m2_Method.prototype.__init_fields__ = interfaces_Baz_m2_Method__init_fields__;
 
 function interfaces_Baz_m2_Method_invoke(object, args) {
-    var obj = object;
-    (obj).m2((args)[0]);
+    var obj = _qrt.cast(object, function () { return interfaces.Baz; });
+    (obj).m2(_qrt.cast((args)[0], function () { return Number; }));
     return null;
 }
 interfaces_Baz_m2_Method.prototype.invoke = interfaces_Baz_m2_Method_invoke;
 
 function interfaces_Baz_m2_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_Baz_m2_Method.prototype._getClass = interfaces_Baz_m2_Method__getClass;
 
@@ -3474,14 +3474,14 @@ function interfaces_Baz_m1_Method__init_fields__() {
 interfaces_Baz_m1_Method.prototype.__init_fields__ = interfaces_Baz_m1_Method__init_fields__;
 
 function interfaces_Baz_m1_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.Baz; });
     (obj).m1();
     return null;
 }
 interfaces_Baz_m1_Method.prototype.invoke = interfaces_Baz_m1_Method_invoke;
 
 function interfaces_Baz_m1_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_Baz_m1_Method.prototype._getClass = interfaces_Baz_m1_Method__getClass;
 
@@ -3507,14 +3507,14 @@ function interfaces_Baz_m3_Method__init_fields__() {
 interfaces_Baz_m3_Method.prototype.__init_fields__ = interfaces_Baz_m3_Method__init_fields__;
 
 function interfaces_Baz_m3_Method_invoke(object, args) {
-    var obj = object;
-    (obj).m3((args)[0]);
+    var obj = _qrt.cast(object, function () { return interfaces.Baz; });
+    (obj).m3(_qrt.cast((args)[0], function () { return Array; }));
     return null;
 }
 interfaces_Baz_m3_Method.prototype.invoke = interfaces_Baz_m3_Method_invoke;
 
 function interfaces_Baz_m3_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_Baz_m3_Method.prototype._getClass = interfaces_Baz_m3_Method__getClass;
 
@@ -3549,7 +3549,7 @@ function interfaces_Baz_construct(args) {
 interfaces_Baz.prototype.construct = interfaces_Baz_construct;
 
 function interfaces_Baz__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_Baz.prototype._getClass = interfaces_Baz__getClass;
 
@@ -3576,14 +3576,14 @@ function interfaces_RazBar_m1_Method__init_fields__() {
 interfaces_RazBar_m1_Method.prototype.__init_fields__ = interfaces_RazBar_m1_Method__init_fields__;
 
 function interfaces_RazBar_m1_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.RazBar; });
     (obj).m1();
     return null;
 }
 interfaces_RazBar_m1_Method.prototype.invoke = interfaces_RazBar_m1_Method_invoke;
 
 function interfaces_RazBar_m1_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_RazBar_m1_Method.prototype._getClass = interfaces_RazBar_m1_Method__getClass;
 
@@ -3609,14 +3609,14 @@ function interfaces_RazBar_m2_Method__init_fields__() {
 interfaces_RazBar_m2_Method.prototype.__init_fields__ = interfaces_RazBar_m2_Method__init_fields__;
 
 function interfaces_RazBar_m2_Method_invoke(object, args) {
-    var obj = object;
-    (obj).m2((args)[0]);
+    var obj = _qrt.cast(object, function () { return interfaces.RazBar; });
+    (obj).m2(_qrt.cast((args)[0], function () { return String; }));
     return null;
 }
 interfaces_RazBar_m2_Method.prototype.invoke = interfaces_RazBar_m2_Method_invoke;
 
 function interfaces_RazBar_m2_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_RazBar_m2_Method.prototype._getClass = interfaces_RazBar_m2_Method__getClass;
 
@@ -3642,14 +3642,14 @@ function interfaces_RazBar_m3_Method__init_fields__() {
 interfaces_RazBar_m3_Method.prototype.__init_fields__ = interfaces_RazBar_m3_Method__init_fields__;
 
 function interfaces_RazBar_m3_Method_invoke(object, args) {
-    var obj = object;
-    (obj).m3((args)[0]);
+    var obj = _qrt.cast(object, function () { return interfaces.RazBar; });
+    (obj).m3(_qrt.cast((args)[0], function () { return Array; }));
     return null;
 }
 interfaces_RazBar_m3_Method.prototype.invoke = interfaces_RazBar_m3_Method_invoke;
 
 function interfaces_RazBar_m3_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_RazBar_m3_Method.prototype._getClass = interfaces_RazBar_m3_Method__getClass;
 
@@ -3684,7 +3684,7 @@ function interfaces_RazBar_construct(args) {
 interfaces_RazBar.prototype.construct = interfaces_RazBar_construct;
 
 function interfaces_RazBar__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_RazBar.prototype._getClass = interfaces_RazBar__getClass;
 
@@ -3711,14 +3711,14 @@ function interfaces_RazFaz_quark_Object__m1_Method__init_fields__() {
 interfaces_RazFaz_quark_Object__m1_Method.prototype.__init_fields__ = interfaces_RazFaz_quark_Object__m1_Method__init_fields__;
 
 function interfaces_RazFaz_quark_Object__m1_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.RazFaz; });
     (obj).m1();
     return null;
 }
 interfaces_RazFaz_quark_Object__m1_Method.prototype.invoke = interfaces_RazFaz_quark_Object__m1_Method_invoke;
 
 function interfaces_RazFaz_quark_Object__m1_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_RazFaz_quark_Object__m1_Method.prototype._getClass = interfaces_RazFaz_quark_Object__m1_Method__getClass;
 
@@ -3744,14 +3744,14 @@ function interfaces_RazFaz_quark_Object__m2_Method__init_fields__() {
 interfaces_RazFaz_quark_Object__m2_Method.prototype.__init_fields__ = interfaces_RazFaz_quark_Object__m2_Method__init_fields__;
 
 function interfaces_RazFaz_quark_Object__m2_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.RazFaz; });
     (obj).m2((args)[0]);
     return null;
 }
 interfaces_RazFaz_quark_Object__m2_Method.prototype.invoke = interfaces_RazFaz_quark_Object__m2_Method_invoke;
 
 function interfaces_RazFaz_quark_Object__m2_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_RazFaz_quark_Object__m2_Method.prototype._getClass = interfaces_RazFaz_quark_Object__m2_Method__getClass;
 
@@ -3777,14 +3777,14 @@ function interfaces_RazFaz_quark_Object__m3_Method__init_fields__() {
 interfaces_RazFaz_quark_Object__m3_Method.prototype.__init_fields__ = interfaces_RazFaz_quark_Object__m3_Method__init_fields__;
 
 function interfaces_RazFaz_quark_Object__m3_Method_invoke(object, args) {
-    var obj = object;
-    (obj).m3((args)[0]);
+    var obj = _qrt.cast(object, function () { return interfaces.RazFaz; });
+    (obj).m3(_qrt.cast((args)[0], function () { return Array; }));
     return null;
 }
 interfaces_RazFaz_quark_Object__m3_Method.prototype.invoke = interfaces_RazFaz_quark_Object__m3_Method_invoke;
 
 function interfaces_RazFaz_quark_Object__m3_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_RazFaz_quark_Object__m3_Method.prototype._getClass = interfaces_RazFaz_quark_Object__m3_Method__getClass;
 
@@ -3819,7 +3819,7 @@ function interfaces_RazFaz_quark_Object__construct(args) {
 interfaces_RazFaz_quark_Object_.prototype.construct = interfaces_RazFaz_quark_Object__construct;
 
 function interfaces_RazFaz_quark_Object___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_RazFaz_quark_Object_.prototype._getClass = interfaces_RazFaz_quark_Object___getClass;
 
@@ -3846,14 +3846,14 @@ function interfaces_BazBar_m1_Method__init_fields__() {
 interfaces_BazBar_m1_Method.prototype.__init_fields__ = interfaces_BazBar_m1_Method__init_fields__;
 
 function interfaces_BazBar_m1_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.BazBar; });
     (obj).m1();
     return null;
 }
 interfaces_BazBar_m1_Method.prototype.invoke = interfaces_BazBar_m1_Method_invoke;
 
 function interfaces_BazBar_m1_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_BazBar_m1_Method.prototype._getClass = interfaces_BazBar_m1_Method__getClass;
 
@@ -3879,14 +3879,14 @@ function interfaces_BazBar_m2_Method__init_fields__() {
 interfaces_BazBar_m2_Method.prototype.__init_fields__ = interfaces_BazBar_m2_Method__init_fields__;
 
 function interfaces_BazBar_m2_Method_invoke(object, args) {
-    var obj = object;
-    (obj).m2((args)[0]);
+    var obj = _qrt.cast(object, function () { return interfaces.BazBar; });
+    (obj).m2(_qrt.cast((args)[0], function () { return String; }));
     return null;
 }
 interfaces_BazBar_m2_Method.prototype.invoke = interfaces_BazBar_m2_Method_invoke;
 
 function interfaces_BazBar_m2_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_BazBar_m2_Method.prototype._getClass = interfaces_BazBar_m2_Method__getClass;
 
@@ -3912,14 +3912,14 @@ function interfaces_BazBar_m3_Method__init_fields__() {
 interfaces_BazBar_m3_Method.prototype.__init_fields__ = interfaces_BazBar_m3_Method__init_fields__;
 
 function interfaces_BazBar_m3_Method_invoke(object, args) {
-    var obj = object;
-    (obj).m3((args)[0]);
+    var obj = _qrt.cast(object, function () { return interfaces.BazBar; });
+    (obj).m3(_qrt.cast((args)[0], function () { return Array; }));
     return null;
 }
 interfaces_BazBar_m3_Method.prototype.invoke = interfaces_BazBar_m3_Method_invoke;
 
 function interfaces_BazBar_m3_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_BazBar_m3_Method.prototype._getClass = interfaces_BazBar_m3_Method__getClass;
 
@@ -3954,7 +3954,7 @@ function interfaces_BazBar_construct(args) {
 interfaces_BazBar.prototype.construct = interfaces_BazBar_construct;
 
 function interfaces_BazBar__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_BazBar.prototype._getClass = interfaces_BazBar__getClass;
 
@@ -3981,14 +3981,14 @@ function interfaces_BazFaz_quark_Object__m1_Method__init_fields__() {
 interfaces_BazFaz_quark_Object__m1_Method.prototype.__init_fields__ = interfaces_BazFaz_quark_Object__m1_Method__init_fields__;
 
 function interfaces_BazFaz_quark_Object__m1_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.BazFaz; });
     (obj).m1();
     return null;
 }
 interfaces_BazFaz_quark_Object__m1_Method.prototype.invoke = interfaces_BazFaz_quark_Object__m1_Method_invoke;
 
 function interfaces_BazFaz_quark_Object__m1_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_BazFaz_quark_Object__m1_Method.prototype._getClass = interfaces_BazFaz_quark_Object__m1_Method__getClass;
 
@@ -4014,14 +4014,14 @@ function interfaces_BazFaz_quark_Object__m2_Method__init_fields__() {
 interfaces_BazFaz_quark_Object__m2_Method.prototype.__init_fields__ = interfaces_BazFaz_quark_Object__m2_Method__init_fields__;
 
 function interfaces_BazFaz_quark_Object__m2_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return interfaces.BazFaz; });
     (obj).m2((args)[0]);
     return null;
 }
 interfaces_BazFaz_quark_Object__m2_Method.prototype.invoke = interfaces_BazFaz_quark_Object__m2_Method_invoke;
 
 function interfaces_BazFaz_quark_Object__m2_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_BazFaz_quark_Object__m2_Method.prototype._getClass = interfaces_BazFaz_quark_Object__m2_Method__getClass;
 
@@ -4047,14 +4047,14 @@ function interfaces_BazFaz_quark_Object__m3_Method__init_fields__() {
 interfaces_BazFaz_quark_Object__m3_Method.prototype.__init_fields__ = interfaces_BazFaz_quark_Object__m3_Method__init_fields__;
 
 function interfaces_BazFaz_quark_Object__m3_Method_invoke(object, args) {
-    var obj = object;
-    (obj).m3((args)[0]);
+    var obj = _qrt.cast(object, function () { return interfaces.BazFaz; });
+    (obj).m3(_qrt.cast((args)[0], function () { return Array; }));
     return null;
 }
 interfaces_BazFaz_quark_Object__m3_Method.prototype.invoke = interfaces_BazFaz_quark_Object__m3_Method_invoke;
 
 function interfaces_BazFaz_quark_Object__m3_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_BazFaz_quark_Object__m3_Method.prototype._getClass = interfaces_BazFaz_quark_Object__m3_Method__getClass;
 
@@ -4089,7 +4089,7 @@ function interfaces_BazFaz_quark_Object__construct(args) {
 interfaces_BazFaz_quark_Object_.prototype.construct = interfaces_BazFaz_quark_Object__construct;
 
 function interfaces_BazFaz_quark_Object___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 interfaces_BazFaz_quark_Object_.prototype._getClass = interfaces_BazFaz_quark_Object___getClass;
 
@@ -4116,13 +4116,13 @@ function classes_Overload___add___Method__init_fields__() {
 classes_Overload___add___Method.prototype.__init_fields__ = classes_Overload___add___Method__init_fields__;
 
 function classes_Overload___add___Method_invoke(object, args) {
-    var obj = object;
-    return (obj).__add__((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.Overload; });
+    return (obj).__add__(_qrt.cast((args)[0], function () { return classes.Overload; }));
 }
 classes_Overload___add___Method.prototype.invoke = classes_Overload___add___Method_invoke;
 
 function classes_Overload___add___Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_Overload___add___Method.prototype._getClass = classes_Overload___add___Method__getClass;
 
@@ -4148,13 +4148,13 @@ function classes_Overload___mul___Method__init_fields__() {
 classes_Overload___mul___Method.prototype.__init_fields__ = classes_Overload___mul___Method__init_fields__;
 
 function classes_Overload___mul___Method_invoke(object, args) {
-    var obj = object;
-    return (obj).__mul__((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.Overload; });
+    return (obj).__mul__(_qrt.cast((args)[0], function () { return classes.Overload; }));
 }
 classes_Overload___mul___Method.prototype.invoke = classes_Overload___mul___Method_invoke;
 
 function classes_Overload___mul___Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_Overload___mul___Method.prototype._getClass = classes_Overload___mul___Method__getClass;
 
@@ -4180,14 +4180,14 @@ function classes_Overload_test_Method__init_fields__() {
 classes_Overload_test_Method.prototype.__init_fields__ = classes_Overload_test_Method__init_fields__;
 
 function classes_Overload_test_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return classes.Overload; });
     (obj).test();
     return null;
 }
 classes_Overload_test_Method.prototype.invoke = classes_Overload_test_Method_invoke;
 
 function classes_Overload_test_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_Overload_test_Method.prototype._getClass = classes_Overload_test_Method__getClass;
 
@@ -4217,12 +4217,12 @@ function classes_Overload__init_fields__() {
 classes_Overload.prototype.__init_fields__ = classes_Overload__init_fields__;
 classes_Overload.singleton = new classes_Overload();
 function classes_Overload_construct(args) {
-    return new classes.Overload((args)[0]);
+    return new classes.Overload(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_Overload.prototype.construct = classes_Overload_construct;
 
 function classes_Overload__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_Overload.prototype._getClass = classes_Overload__getClass;
 
@@ -4249,14 +4249,14 @@ function classes_Test_test_Method__init_fields__() {
 classes_Test_test_Method.prototype.__init_fields__ = classes_Test_test_Method__init_fields__;
 
 function classes_Test_test_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return classes.Test; });
     (obj).test();
     return null;
 }
 classes_Test_test_Method.prototype.invoke = classes_Test_test_Method_invoke;
 
 function classes_Test_test_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_Test_test_Method.prototype._getClass = classes_Test_test_Method__getClass;
 
@@ -4291,7 +4291,7 @@ function classes_Test_construct(args) {
 classes_Test.prototype.construct = classes_Test_construct;
 
 function classes_Test__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_Test.prototype._getClass = classes_Test__getClass;
 
@@ -4318,14 +4318,14 @@ function classes_string_test_check_Method__init_fields__() {
 classes_string_test_check_Method.prototype.__init_fields__ = classes_string_test_check_Method__init_fields__;
 
 function classes_string_test_check_Method_invoke(object, args) {
-    var obj = object;
-    (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+    var obj = _qrt.cast(object, function () { return classes.string_test; });
+    (obj).check(_qrt.cast((args)[0], function () { return String; }), _qrt.cast((args)[1], function () { return String; }), _qrt.cast((args)[2], function () { return String; }), _qrt.cast((args)[3], function () { return String; }));
     return null;
 }
 classes_string_test_check_Method.prototype.invoke = classes_string_test_check_Method_invoke;
 
 function classes_string_test_check_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_string_test_check_Method.prototype._getClass = classes_string_test_check_Method__getClass;
 
@@ -4360,7 +4360,7 @@ function classes_string_test_construct(args) {
 classes_string_test.prototype.construct = classes_string_test_construct;
 
 function classes_string_test__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_string_test.prototype._getClass = classes_string_test__getClass;
 
@@ -4387,13 +4387,13 @@ function classes_test_size_does_Method__init_fields__() {
 classes_test_size_does_Method.prototype.__init_fields__ = classes_test_size_does_Method__init_fields__;
 
 function classes_test_size_does_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).does((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.test_size; });
+    return (obj).does(_qrt.cast((args)[0], function () { return Number; }));
 }
 classes_test_size_does_Method.prototype.invoke = classes_test_size_does_Method_invoke;
 
 function classes_test_size_does_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_size_does_Method.prototype._getClass = classes_test_size_does_Method__getClass;
 
@@ -4419,14 +4419,14 @@ function classes_test_size_check_Method__init_fields__() {
 classes_test_size_check_Method.prototype.__init_fields__ = classes_test_size_check_Method__init_fields__;
 
 function classes_test_size_check_Method_invoke(object, args) {
-    var obj = object;
-    (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+    var obj = _qrt.cast(object, function () { return classes.test_size; });
+    (obj).check(_qrt.cast((args)[0], function () { return String; }), _qrt.cast((args)[1], function () { return String; }), _qrt.cast((args)[2], function () { return String; }), _qrt.cast((args)[3], function () { return String; }));
     return null;
 }
 classes_test_size_check_Method.prototype.invoke = classes_test_size_check_Method_invoke;
 
 function classes_test_size_check_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_size_check_Method.prototype._getClass = classes_test_size_check_Method__getClass;
 
@@ -4456,12 +4456,12 @@ function classes_test_size__init_fields__() {
 classes_test_size.prototype.__init_fields__ = classes_test_size__init_fields__;
 classes_test_size.singleton = new classes_test_size();
 function classes_test_size_construct(args) {
-    return new classes.test_size((args)[0]);
+    return new classes.test_size(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_size.prototype.construct = classes_test_size_construct;
 
 function classes_test_size__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_size.prototype._getClass = classes_test_size__getClass;
 
@@ -4488,13 +4488,13 @@ function classes_test_startsWith_that_Method__init_fields__() {
 classes_test_startsWith_that_Method.prototype.__init_fields__ = classes_test_startsWith_that_Method__init_fields__;
 
 function classes_test_startsWith_that_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).that((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.test_startsWith; });
+    return (obj).that(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_startsWith_that_Method.prototype.invoke = classes_test_startsWith_that_Method_invoke;
 
 function classes_test_startsWith_that_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_startsWith_that_Method.prototype._getClass = classes_test_startsWith_that_Method__getClass;
 
@@ -4520,13 +4520,13 @@ function classes_test_startsWith_does_Method__init_fields__() {
 classes_test_startsWith_does_Method.prototype.__init_fields__ = classes_test_startsWith_does_Method__init_fields__;
 
 function classes_test_startsWith_does_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).does((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.test_startsWith; });
+    return (obj).does(_qrt.cast((args)[0], function () { return Boolean; }));
 }
 classes_test_startsWith_does_Method.prototype.invoke = classes_test_startsWith_does_Method_invoke;
 
 function classes_test_startsWith_does_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_startsWith_does_Method.prototype._getClass = classes_test_startsWith_does_Method__getClass;
 
@@ -4552,14 +4552,14 @@ function classes_test_startsWith_check_Method__init_fields__() {
 classes_test_startsWith_check_Method.prototype.__init_fields__ = classes_test_startsWith_check_Method__init_fields__;
 
 function classes_test_startsWith_check_Method_invoke(object, args) {
-    var obj = object;
-    (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+    var obj = _qrt.cast(object, function () { return classes.test_startsWith; });
+    (obj).check(_qrt.cast((args)[0], function () { return String; }), _qrt.cast((args)[1], function () { return String; }), _qrt.cast((args)[2], function () { return String; }), _qrt.cast((args)[3], function () { return String; }));
     return null;
 }
 classes_test_startsWith_check_Method.prototype.invoke = classes_test_startsWith_check_Method_invoke;
 
 function classes_test_startsWith_check_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_startsWith_check_Method.prototype._getClass = classes_test_startsWith_check_Method__getClass;
 
@@ -4589,12 +4589,12 @@ function classes_test_startsWith__init_fields__() {
 classes_test_startsWith.prototype.__init_fields__ = classes_test_startsWith__init_fields__;
 classes_test_startsWith.singleton = new classes_test_startsWith();
 function classes_test_startsWith_construct(args) {
-    return new classes.test_startsWith((args)[0]);
+    return new classes.test_startsWith(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_startsWith.prototype.construct = classes_test_startsWith_construct;
 
 function classes_test_startsWith__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_startsWith.prototype._getClass = classes_test_startsWith__getClass;
 
@@ -4621,13 +4621,13 @@ function classes_test_endsWith_that_Method__init_fields__() {
 classes_test_endsWith_that_Method.prototype.__init_fields__ = classes_test_endsWith_that_Method__init_fields__;
 
 function classes_test_endsWith_that_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).that((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.test_endsWith; });
+    return (obj).that(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_endsWith_that_Method.prototype.invoke = classes_test_endsWith_that_Method_invoke;
 
 function classes_test_endsWith_that_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_endsWith_that_Method.prototype._getClass = classes_test_endsWith_that_Method__getClass;
 
@@ -4653,13 +4653,13 @@ function classes_test_endsWith_does_Method__init_fields__() {
 classes_test_endsWith_does_Method.prototype.__init_fields__ = classes_test_endsWith_does_Method__init_fields__;
 
 function classes_test_endsWith_does_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).does((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.test_endsWith; });
+    return (obj).does(_qrt.cast((args)[0], function () { return Boolean; }));
 }
 classes_test_endsWith_does_Method.prototype.invoke = classes_test_endsWith_does_Method_invoke;
 
 function classes_test_endsWith_does_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_endsWith_does_Method.prototype._getClass = classes_test_endsWith_does_Method__getClass;
 
@@ -4685,14 +4685,14 @@ function classes_test_endsWith_check_Method__init_fields__() {
 classes_test_endsWith_check_Method.prototype.__init_fields__ = classes_test_endsWith_check_Method__init_fields__;
 
 function classes_test_endsWith_check_Method_invoke(object, args) {
-    var obj = object;
-    (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+    var obj = _qrt.cast(object, function () { return classes.test_endsWith; });
+    (obj).check(_qrt.cast((args)[0], function () { return String; }), _qrt.cast((args)[1], function () { return String; }), _qrt.cast((args)[2], function () { return String; }), _qrt.cast((args)[3], function () { return String; }));
     return null;
 }
 classes_test_endsWith_check_Method.prototype.invoke = classes_test_endsWith_check_Method_invoke;
 
 function classes_test_endsWith_check_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_endsWith_check_Method.prototype._getClass = classes_test_endsWith_check_Method__getClass;
 
@@ -4722,12 +4722,12 @@ function classes_test_endsWith__init_fields__() {
 classes_test_endsWith.prototype.__init_fields__ = classes_test_endsWith__init_fields__;
 classes_test_endsWith.singleton = new classes_test_endsWith();
 function classes_test_endsWith_construct(args) {
-    return new classes.test_endsWith((args)[0]);
+    return new classes.test_endsWith(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_endsWith.prototype.construct = classes_test_endsWith_construct;
 
 function classes_test_endsWith__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_endsWith.prototype._getClass = classes_test_endsWith__getClass;
 
@@ -4754,13 +4754,13 @@ function classes_test_find_that_Method__init_fields__() {
 classes_test_find_that_Method.prototype.__init_fields__ = classes_test_find_that_Method__init_fields__;
 
 function classes_test_find_that_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).that((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.test_find; });
+    return (obj).that(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_find_that_Method.prototype.invoke = classes_test_find_that_Method_invoke;
 
 function classes_test_find_that_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_find_that_Method.prototype._getClass = classes_test_find_that_Method__getClass;
 
@@ -4786,13 +4786,13 @@ function classes_test_find_does_Method__init_fields__() {
 classes_test_find_does_Method.prototype.__init_fields__ = classes_test_find_does_Method__init_fields__;
 
 function classes_test_find_does_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).does((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.test_find; });
+    return (obj).does(_qrt.cast((args)[0], function () { return Number; }));
 }
 classes_test_find_does_Method.prototype.invoke = classes_test_find_does_Method_invoke;
 
 function classes_test_find_does_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_find_does_Method.prototype._getClass = classes_test_find_does_Method__getClass;
 
@@ -4818,14 +4818,14 @@ function classes_test_find_check_Method__init_fields__() {
 classes_test_find_check_Method.prototype.__init_fields__ = classes_test_find_check_Method__init_fields__;
 
 function classes_test_find_check_Method_invoke(object, args) {
-    var obj = object;
-    (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+    var obj = _qrt.cast(object, function () { return classes.test_find; });
+    (obj).check(_qrt.cast((args)[0], function () { return String; }), _qrt.cast((args)[1], function () { return String; }), _qrt.cast((args)[2], function () { return String; }), _qrt.cast((args)[3], function () { return String; }));
     return null;
 }
 classes_test_find_check_Method.prototype.invoke = classes_test_find_check_Method_invoke;
 
 function classes_test_find_check_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_find_check_Method.prototype._getClass = classes_test_find_check_Method__getClass;
 
@@ -4855,12 +4855,12 @@ function classes_test_find__init_fields__() {
 classes_test_find.prototype.__init_fields__ = classes_test_find__init_fields__;
 classes_test_find.singleton = new classes_test_find();
 function classes_test_find_construct(args) {
-    return new classes.test_find((args)[0]);
+    return new classes.test_find(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_find.prototype.construct = classes_test_find_construct;
 
 function classes_test_find__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_find.prototype._getClass = classes_test_find__getClass;
 
@@ -4887,13 +4887,13 @@ function classes_test_substring_that_Method__init_fields__() {
 classes_test_substring_that_Method.prototype.__init_fields__ = classes_test_substring_that_Method__init_fields__;
 
 function classes_test_substring_that_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).that((args)[0], (args)[1]);
+    var obj = _qrt.cast(object, function () { return classes.test_substring; });
+    return (obj).that(_qrt.cast((args)[0], function () { return Number; }), _qrt.cast((args)[1], function () { return Number; }));
 }
 classes_test_substring_that_Method.prototype.invoke = classes_test_substring_that_Method_invoke;
 
 function classes_test_substring_that_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_substring_that_Method.prototype._getClass = classes_test_substring_that_Method__getClass;
 
@@ -4919,13 +4919,13 @@ function classes_test_substring_does_Method__init_fields__() {
 classes_test_substring_does_Method.prototype.__init_fields__ = classes_test_substring_does_Method__init_fields__;
 
 function classes_test_substring_does_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).does((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.test_substring; });
+    return (obj).does(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_substring_does_Method.prototype.invoke = classes_test_substring_does_Method_invoke;
 
 function classes_test_substring_does_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_substring_does_Method.prototype._getClass = classes_test_substring_does_Method__getClass;
 
@@ -4951,14 +4951,14 @@ function classes_test_substring_check_Method__init_fields__() {
 classes_test_substring_check_Method.prototype.__init_fields__ = classes_test_substring_check_Method__init_fields__;
 
 function classes_test_substring_check_Method_invoke(object, args) {
-    var obj = object;
-    (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+    var obj = _qrt.cast(object, function () { return classes.test_substring; });
+    (obj).check(_qrt.cast((args)[0], function () { return String; }), _qrt.cast((args)[1], function () { return String; }), _qrt.cast((args)[2], function () { return String; }), _qrt.cast((args)[3], function () { return String; }));
     return null;
 }
 classes_test_substring_check_Method.prototype.invoke = classes_test_substring_check_Method_invoke;
 
 function classes_test_substring_check_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_substring_check_Method.prototype._getClass = classes_test_substring_check_Method__getClass;
 
@@ -4988,12 +4988,12 @@ function classes_test_substring__init_fields__() {
 classes_test_substring.prototype.__init_fields__ = classes_test_substring__init_fields__;
 classes_test_substring.singleton = new classes_test_substring();
 function classes_test_substring_construct(args) {
-    return new classes.test_substring((args)[0]);
+    return new classes.test_substring(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_substring.prototype.construct = classes_test_substring_construct;
 
 function classes_test_substring__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_substring.prototype._getClass = classes_test_substring__getClass;
 
@@ -5020,13 +5020,13 @@ function classes_test_replace_that_Method__init_fields__() {
 classes_test_replace_that_Method.prototype.__init_fields__ = classes_test_replace_that_Method__init_fields__;
 
 function classes_test_replace_that_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).that((args)[0], (args)[1]);
+    var obj = _qrt.cast(object, function () { return classes.test_replace; });
+    return (obj).that(_qrt.cast((args)[0], function () { return String; }), _qrt.cast((args)[1], function () { return String; }));
 }
 classes_test_replace_that_Method.prototype.invoke = classes_test_replace_that_Method_invoke;
 
 function classes_test_replace_that_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_replace_that_Method.prototype._getClass = classes_test_replace_that_Method__getClass;
 
@@ -5052,13 +5052,13 @@ function classes_test_replace_does_Method__init_fields__() {
 classes_test_replace_does_Method.prototype.__init_fields__ = classes_test_replace_does_Method__init_fields__;
 
 function classes_test_replace_does_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).does((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.test_replace; });
+    return (obj).does(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_replace_does_Method.prototype.invoke = classes_test_replace_does_Method_invoke;
 
 function classes_test_replace_does_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_replace_does_Method.prototype._getClass = classes_test_replace_does_Method__getClass;
 
@@ -5084,14 +5084,14 @@ function classes_test_replace_check_Method__init_fields__() {
 classes_test_replace_check_Method.prototype.__init_fields__ = classes_test_replace_check_Method__init_fields__;
 
 function classes_test_replace_check_Method_invoke(object, args) {
-    var obj = object;
-    (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+    var obj = _qrt.cast(object, function () { return classes.test_replace; });
+    (obj).check(_qrt.cast((args)[0], function () { return String; }), _qrt.cast((args)[1], function () { return String; }), _qrt.cast((args)[2], function () { return String; }), _qrt.cast((args)[3], function () { return String; }));
     return null;
 }
 classes_test_replace_check_Method.prototype.invoke = classes_test_replace_check_Method_invoke;
 
 function classes_test_replace_check_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_replace_check_Method.prototype._getClass = classes_test_replace_check_Method__getClass;
 
@@ -5121,12 +5121,12 @@ function classes_test_replace__init_fields__() {
 classes_test_replace.prototype.__init_fields__ = classes_test_replace__init_fields__;
 classes_test_replace.singleton = new classes_test_replace();
 function classes_test_replace_construct(args) {
-    return new classes.test_replace((args)[0]);
+    return new classes.test_replace(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_replace.prototype.construct = classes_test_replace_construct;
 
 function classes_test_replace__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_replace.prototype._getClass = classes_test_replace__getClass;
 
@@ -5153,13 +5153,13 @@ function classes_test_join_that_Method__init_fields__() {
 classes_test_join_that_Method.prototype.__init_fields__ = classes_test_join_that_Method__init_fields__;
 
 function classes_test_join_that_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return classes.test_join; });
     return (obj).that();
 }
 classes_test_join_that_Method.prototype.invoke = classes_test_join_that_Method_invoke;
 
 function classes_test_join_that_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_join_that_Method.prototype._getClass = classes_test_join_that_Method__getClass;
 
@@ -5185,13 +5185,13 @@ function classes_test_join_a_Method__init_fields__() {
 classes_test_join_a_Method.prototype.__init_fields__ = classes_test_join_a_Method__init_fields__;
 
 function classes_test_join_a_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).a((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.test_join; });
+    return (obj).a(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_join_a_Method.prototype.invoke = classes_test_join_a_Method_invoke;
 
 function classes_test_join_a_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_join_a_Method.prototype._getClass = classes_test_join_a_Method__getClass;
 
@@ -5217,13 +5217,13 @@ function classes_test_join_does_Method__init_fields__() {
 classes_test_join_does_Method.prototype.__init_fields__ = classes_test_join_does_Method__init_fields__;
 
 function classes_test_join_does_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).does((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.test_join; });
+    return (obj).does(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_join_does_Method.prototype.invoke = classes_test_join_does_Method_invoke;
 
 function classes_test_join_does_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_join_does_Method.prototype._getClass = classes_test_join_does_Method__getClass;
 
@@ -5249,14 +5249,14 @@ function classes_test_join_check_Method__init_fields__() {
 classes_test_join_check_Method.prototype.__init_fields__ = classes_test_join_check_Method__init_fields__;
 
 function classes_test_join_check_Method_invoke(object, args) {
-    var obj = object;
-    (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+    var obj = _qrt.cast(object, function () { return classes.test_join; });
+    (obj).check(_qrt.cast((args)[0], function () { return String; }), _qrt.cast((args)[1], function () { return String; }), _qrt.cast((args)[2], function () { return String; }), _qrt.cast((args)[3], function () { return String; }));
     return null;
 }
 classes_test_join_check_Method.prototype.invoke = classes_test_join_check_Method_invoke;
 
 function classes_test_join_check_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_join_check_Method.prototype._getClass = classes_test_join_check_Method__getClass;
 
@@ -5286,12 +5286,12 @@ function classes_test_join__init_fields__() {
 classes_test_join.prototype.__init_fields__ = classes_test_join__init_fields__;
 classes_test_join.singleton = new classes_test_join();
 function classes_test_join_construct(args) {
-    return new classes.test_join((args)[0]);
+    return new classes.test_join(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_join.prototype.construct = classes_test_join_construct;
 
 function classes_test_join__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_join.prototype._getClass = classes_test_join__getClass;
 
@@ -5318,13 +5318,13 @@ function classes_test_split_that_Method__init_fields__() {
 classes_test_split_that_Method.prototype.__init_fields__ = classes_test_split_that_Method__init_fields__;
 
 function classes_test_split_that_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).that((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.test_split; });
+    return (obj).that(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_split_that_Method.prototype.invoke = classes_test_split_that_Method_invoke;
 
 function classes_test_split_that_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_split_that_Method.prototype._getClass = classes_test_split_that_Method__getClass;
 
@@ -5350,13 +5350,13 @@ function classes_test_split_does_Method__init_fields__() {
 classes_test_split_does_Method.prototype.__init_fields__ = classes_test_split_does_Method__init_fields__;
 
 function classes_test_split_does_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).does((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.test_split; });
+    return (obj).does(_qrt.cast((args)[0], function () { return String; }));
 }
 classes_test_split_does_Method.prototype.invoke = classes_test_split_does_Method_invoke;
 
 function classes_test_split_does_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_split_does_Method.prototype._getClass = classes_test_split_does_Method__getClass;
 
@@ -5382,14 +5382,14 @@ function classes_test_split_check_Method__init_fields__() {
 classes_test_split_check_Method.prototype.__init_fields__ = classes_test_split_check_Method__init_fields__;
 
 function classes_test_split_check_Method_invoke(object, args) {
-    var obj = object;
-    (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+    var obj = _qrt.cast(object, function () { return classes.test_split; });
+    (obj).check(_qrt.cast((args)[0], function () { return String; }), _qrt.cast((args)[1], function () { return String; }), _qrt.cast((args)[2], function () { return String; }), _qrt.cast((args)[3], function () { return String; }));
     return null;
 }
 classes_test_split_check_Method.prototype.invoke = classes_test_split_check_Method_invoke;
 
 function classes_test_split_check_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_split_check_Method.prototype._getClass = classes_test_split_check_Method__getClass;
 
@@ -5419,12 +5419,12 @@ function classes_test_split__init_fields__() {
 classes_test_split.prototype.__init_fields__ = classes_test_split__init_fields__;
 classes_test_split.singleton = new classes_test_split();
 function classes_test_split_construct(args) {
-    return new classes.test_split((args)[0], (args)[1]);
+    return new classes.test_split(_qrt.cast((args)[0], function () { return String; }), _qrt.cast((args)[1], function () { return String; }));
 }
 classes_test_split.prototype.construct = classes_test_split_construct;
 
 function classes_test_split__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_test_split.prototype._getClass = classes_test_split__getClass;
 
@@ -5451,13 +5451,13 @@ function classes_stuff_Test_foo_Method__init_fields__() {
 classes_stuff_Test_foo_Method.prototype.__init_fields__ = classes_stuff_Test_foo_Method__init_fields__;
 
 function classes_stuff_Test_foo_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).foo((args)[0]);
+    var obj = _qrt.cast(object, function () { return classes.stuff.Test; });
+    return (obj).foo(_qrt.cast((args)[0], function () { return classes.stuff.Test; }));
 }
 classes_stuff_Test_foo_Method.prototype.invoke = classes_stuff_Test_foo_Method_invoke;
 
 function classes_stuff_Test_foo_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_stuff_Test_foo_Method.prototype._getClass = classes_stuff_Test_foo_Method__getClass;
 
@@ -5483,14 +5483,14 @@ function classes_stuff_Test_test_Method__init_fields__() {
 classes_stuff_Test_test_Method.prototype.__init_fields__ = classes_stuff_Test_test_Method__init_fields__;
 
 function classes_stuff_Test_test_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return classes.stuff.Test; });
     (obj).test();
     return null;
 }
 classes_stuff_Test_test_Method.prototype.invoke = classes_stuff_Test_test_Method_invoke;
 
 function classes_stuff_Test_test_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_stuff_Test_test_Method.prototype._getClass = classes_stuff_Test_test_Method__getClass;
 
@@ -5525,7 +5525,7 @@ function classes_stuff_Test_construct(args) {
 classes_stuff_Test.prototype.construct = classes_stuff_Test_construct;
 
 function classes_stuff_Test__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 classes_stuff_Test.prototype._getClass = classes_stuff_Test__getClass;
 
@@ -5552,14 +5552,14 @@ function statics_Foo_setCount_Method__init_fields__() {
 statics_Foo_setCount_Method.prototype.__init_fields__ = statics_Foo_setCount_Method__init_fields__;
 
 function statics_Foo_setCount_Method_invoke(object, args) {
-    var obj = object;
-    statics.Foo.setCount((args)[0]);
+    var obj = _qrt.cast(object, function () { return statics.Foo; });
+    statics.Foo.setCount(_qrt.cast((args)[0], function () { return Number; }));
     return null;
 }
 statics_Foo_setCount_Method.prototype.invoke = statics_Foo_setCount_Method_invoke;
 
 function statics_Foo_setCount_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 statics_Foo_setCount_Method.prototype._getClass = statics_Foo_setCount_Method__getClass;
 
@@ -5585,13 +5585,13 @@ function statics_Foo_getCount_Method__init_fields__() {
 statics_Foo_getCount_Method.prototype.__init_fields__ = statics_Foo_getCount_Method__init_fields__;
 
 function statics_Foo_getCount_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return statics.Foo; });
     return statics.Foo.getCount();
 }
 statics_Foo_getCount_Method.prototype.invoke = statics_Foo_getCount_Method_invoke;
 
 function statics_Foo_getCount_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 statics_Foo_getCount_Method.prototype._getClass = statics_Foo_getCount_Method__getClass;
 
@@ -5617,14 +5617,14 @@ function statics_Foo_test1_Method__init_fields__() {
 statics_Foo_test1_Method.prototype.__init_fields__ = statics_Foo_test1_Method__init_fields__;
 
 function statics_Foo_test1_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return statics.Foo; });
     (obj).test1();
     return null;
 }
 statics_Foo_test1_Method.prototype.invoke = statics_Foo_test1_Method_invoke;
 
 function statics_Foo_test1_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 statics_Foo_test1_Method.prototype._getClass = statics_Foo_test1_Method__getClass;
 
@@ -5650,14 +5650,14 @@ function statics_Foo_test2_Method__init_fields__() {
 statics_Foo_test2_Method.prototype.__init_fields__ = statics_Foo_test2_Method__init_fields__;
 
 function statics_Foo_test2_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return statics.Foo; });
     (obj).test2();
     return null;
 }
 statics_Foo_test2_Method.prototype.invoke = statics_Foo_test2_Method_invoke;
 
 function statics_Foo_test2_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 statics_Foo_test2_Method.prototype._getClass = statics_Foo_test2_Method__getClass;
 
@@ -5683,14 +5683,14 @@ function statics_Foo_test3_Method__init_fields__() {
 statics_Foo_test3_Method.prototype.__init_fields__ = statics_Foo_test3_Method__init_fields__;
 
 function statics_Foo_test3_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return statics.Foo; });
     (obj).test3();
     return null;
 }
 statics_Foo_test3_Method.prototype.invoke = statics_Foo_test3_Method_invoke;
 
 function statics_Foo_test3_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 statics_Foo_test3_Method.prototype._getClass = statics_Foo_test3_Method__getClass;
 
@@ -5716,14 +5716,14 @@ function statics_Foo_test4_Method__init_fields__() {
 statics_Foo_test4_Method.prototype.__init_fields__ = statics_Foo_test4_Method__init_fields__;
 
 function statics_Foo_test4_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return statics.Foo; });
     (obj).test4();
     return null;
 }
 statics_Foo_test4_Method.prototype.invoke = statics_Foo_test4_Method_invoke;
 
 function statics_Foo_test4_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 statics_Foo_test4_Method.prototype._getClass = statics_Foo_test4_Method__getClass;
 
@@ -5758,7 +5758,7 @@ function statics_Foo_construct(args) {
 statics_Foo.prototype.construct = statics_Foo_construct;
 
 function statics_Foo__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 statics_Foo.prototype._getClass = statics_Foo__getClass;
 
@@ -5785,13 +5785,13 @@ function docs_Test_test_Method__init_fields__() {
 docs_Test_test_Method.prototype.__init_fields__ = docs_Test_test_Method__init_fields__;
 
 function docs_Test_test_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).test((args)[0]);
+    var obj = _qrt.cast(object, function () { return docs.Test; });
+    return (obj).test(_qrt.cast((args)[0], function () { return String; }));
 }
 docs_Test_test_Method.prototype.invoke = docs_Test_test_Method_invoke;
 
 function docs_Test_test_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 docs_Test_test_Method.prototype._getClass = docs_Test_test_Method__getClass;
 
@@ -5826,7 +5826,7 @@ function docs_Test_construct(args) {
 docs_Test.prototype.construct = docs_Test_construct;
 
 function docs_Test__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 docs_Test.prototype._getClass = docs_Test__getClass;
 
@@ -5862,7 +5862,7 @@ function quark_List_quark_List_quark_Object___construct(args) {
 quark_List_quark_List_quark_Object__.prototype.construct = quark_List_quark_List_quark_Object___construct;
 
 function quark_List_quark_List_quark_Object____getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 quark_List_quark_List_quark_Object__.prototype._getClass = quark_List_quark_List_quark_Object____getClass;
 
@@ -5898,7 +5898,7 @@ function quark_List_quark_Object__construct(args) {
 quark_List_quark_Object_.prototype.construct = quark_List_quark_Object__construct;
 
 function quark_List_quark_Object___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 quark_List_quark_Object_.prototype._getClass = quark_List_quark_Object___getClass;
 
@@ -5934,7 +5934,7 @@ function quark_List_quark_String__construct(args) {
 quark_List_quark_String_.prototype.construct = quark_List_quark_String__construct;
 
 function quark_List_quark_String___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 quark_List_quark_String_.prototype._getClass = quark_List_quark_String___getClass;
 
@@ -6025,7 +6025,7 @@ Root.quark_List_quark_List_quark_Object___md = quark_List_quark_List_quark_Objec
 Root.quark_List_quark_Object__md = quark_List_quark_Object_.singleton;
 Root.quark_List_quark_String__md = quark_List_quark_String_.singleton;
 function Root__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 Root.prototype._getClass = Root__getClass;
 

--- a/quarkc/test/ffi/expected/js/signatures/statics/index.js
+++ b/quarkc/test/ffi/expected/js/signatures/statics/index.js
@@ -52,7 +52,7 @@ Foo.prototype._getField = Foo__getField;
 
 function Foo__setField(name, value) {
     if (_qrt.equals((name), ("count"))) {
-        Foo.count = value;
+        Foo.count = _qrt.cast(value, function () { return Number; });
     }
 }
 Foo.prototype._setField = Foo__setField;

--- a/quarkc/test/ffi/expected/js/slackpack/slack/event/index.js
+++ b/quarkc/test/ffi/expected/js/slackpack/slack/event/index.js
@@ -67,16 +67,16 @@ SlackEvent.prototype._getField = SlackEvent__getField;
 
 function SlackEvent__setField(name, value) {
     if (_qrt.equals((name), ("type"))) {
-        (this).type = value;
+        (this).type = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("user"))) {
-        (this).user = value;
+        (this).user = _qrt.cast(value, function () { return slack.User; });
     }
     if (_qrt.equals((name), ("channel"))) {
-        (this).channel = value;
+        (this).channel = _qrt.cast(value, function () { return slack.Channel; });
     }
     if (_qrt.equals((name), ("timestamp"))) {
-        (this).timestamp = value;
+        (this).timestamp = _qrt.cast(value, function () { return String; });
     }
 }
 SlackEvent.prototype._setField = SlackEvent__setField;
@@ -141,22 +141,22 @@ SlackError.prototype._getField = SlackError__getField;
 
 function SlackError__setField(name, value) {
     if (_qrt.equals((name), ("type"))) {
-        (this).type = value;
+        (this).type = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("user"))) {
-        (this).user = value;
+        (this).user = _qrt.cast(value, function () { return slack.User; });
     }
     if (_qrt.equals((name), ("channel"))) {
-        (this).channel = value;
+        (this).channel = _qrt.cast(value, function () { return slack.Channel; });
     }
     if (_qrt.equals((name), ("timestamp"))) {
-        (this).timestamp = value;
+        (this).timestamp = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("code"))) {
-        (this).code = value;
+        (this).code = _qrt.cast(value, function () { return Number; });
     }
     if (_qrt.equals((name), ("text"))) {
-        (this).text = value;
+        (this).text = _qrt.cast(value, function () { return String; });
     }
 }
 SlackError.prototype._setField = SlackError__setField;
@@ -204,16 +204,16 @@ Hello.prototype._getField = Hello__getField;
 
 function Hello__setField(name, value) {
     if (_qrt.equals((name), ("type"))) {
-        (this).type = value;
+        (this).type = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("user"))) {
-        (this).user = value;
+        (this).user = _qrt.cast(value, function () { return slack.User; });
     }
     if (_qrt.equals((name), ("channel"))) {
-        (this).channel = value;
+        (this).channel = _qrt.cast(value, function () { return slack.Channel; });
     }
     if (_qrt.equals((name), ("timestamp"))) {
-        (this).timestamp = value;
+        (this).timestamp = _qrt.cast(value, function () { return String; });
     }
 }
 Hello.prototype._setField = Hello__setField;
@@ -283,28 +283,28 @@ Message.prototype._getField = Message__getField;
 
 function Message__setField(name, value) {
     if (_qrt.equals((name), ("type"))) {
-        (this).type = value;
+        (this).type = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("user"))) {
-        (this).user = value;
+        (this).user = _qrt.cast(value, function () { return slack.User; });
     }
     if (_qrt.equals((name), ("channel"))) {
-        (this).channel = value;
+        (this).channel = _qrt.cast(value, function () { return slack.Channel; });
     }
     if (_qrt.equals((name), ("timestamp"))) {
-        (this).timestamp = value;
+        (this).timestamp = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("subtype"))) {
-        (this).subtype = value;
+        (this).subtype = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("hidden"))) {
-        (this).hidden = value;
+        (this).hidden = _qrt.cast(value, function () { return Boolean; });
     }
     if (_qrt.equals((name), ("text"))) {
-        (this).text = value;
+        (this).text = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("edited"))) {
-        (this).edited = value;
+        (this).edited = _qrt.cast(value, function () { return Edited; });
     }
 }
 Message.prototype._setField = Message__setField;
@@ -342,10 +342,10 @@ Edited.prototype._getField = Edited__getField;
 
 function Edited__setField(name, value) {
     if (_qrt.equals((name), ("user"))) {
-        (this).user = value;
+        (this).user = _qrt.cast(value, function () { return slack.User; });
     }
     if (_qrt.equals((name), ("timestamp"))) {
-        (this).timestamp = value;
+        (this).timestamp = _qrt.cast(value, function () { return String; });
     }
 }
 Edited.prototype._setField = Edited__setField;

--- a/quarkc/test/ffi/expected/js/slackpack/slack/index.js
+++ b/quarkc/test/ffi/expected/js/slackpack/slack/index.js
@@ -69,10 +69,10 @@ User.prototype._getField = User__getField;
 
 function User__setField(name, value) {
     if (_qrt.equals((name), ("client"))) {
-        (this).client = value;
+        (this).client = _qrt.cast(value, function () { return Client; });
     }
     if (_qrt.equals((name), ("user"))) {
-        (this).user = value;
+        (this).user = _qrt.cast(value, function () { return String; });
     }
 }
 User.prototype._setField = User__setField;
@@ -117,10 +117,10 @@ Channel.prototype._getField = Channel__getField;
 
 function Channel__setField(name, value) {
     if (_qrt.equals((name), ("client"))) {
-        (this).client = value;
+        (this).client = _qrt.cast(value, function () { return Client; });
     }
     if (_qrt.equals((name), ("channel"))) {
-        (this).channel = value;
+        (this).channel = _qrt.cast(value, function () { return String; });
     }
 }
 Channel.prototype._setField = Channel__setField;
@@ -170,7 +170,7 @@ function Client_onWSError(socket) {}
 Client.prototype.onWSError = Client_onWSError;
 
 function Client_construct(type) {
-    return null;
+    return _qrt.cast(null, function () { return event.SlackEvent; });
 }
 Client.prototype.construct = Client_construct;
 
@@ -207,19 +207,19 @@ Client.prototype._getField = Client__getField;
 
 function Client__setField(name, value) {
     if (_qrt.equals((name), ("runtime"))) {
-        (this).runtime = value;
+        (this).runtime = _qrt.cast(value, function () { return quark.Runtime; });
     }
     if (_qrt.equals((name), ("token"))) {
-        (this).token = value;
+        (this).token = _qrt.cast(value, function () { return String; });
     }
     if (_qrt.equals((name), ("handler"))) {
-        (this).handler = value;
+        (this).handler = _qrt.cast(value, function () { return SlackHandler; });
     }
     if (_qrt.equals((name), ("event_id"))) {
-        (this).event_id = value;
+        (this).event_id = _qrt.cast(value, function () { return Number; });
     }
     if (_qrt.equals((name), ("socket"))) {
-        (this).socket = value;
+        (this).socket = _qrt.cast(value, function () { return quark.WebSocket; });
     }
 }
 Client.prototype._setField = Client__setField;

--- a/quarkc/test/ffi/expected/js/slackpack/slackpack_md/index.js
+++ b/quarkc/test/ffi/expected/js/slackpack/slackpack_md/index.js
@@ -18,14 +18,14 @@ function slack_event_SlackEvent_load_Method__init_fields__() {
 slack_event_SlackEvent_load_Method.prototype.__init_fields__ = slack_event_SlackEvent_load_Method__init_fields__;
 
 function slack_event_SlackEvent_load_Method_invoke(object, args) {
-    var obj = object;
-    (obj).load((args)[0], (args)[1]);
+    var obj = _qrt.cast(object, function () { return slack.event.SlackEvent; });
+    (obj).load(_qrt.cast((args)[0], function () { return slack.Client; }), _qrt.cast((args)[1], function () { return _qrt.JSONObject; }));
     return null;
 }
 slack_event_SlackEvent_load_Method.prototype.invoke = slack_event_SlackEvent_load_Method_invoke;
 
 function slack_event_SlackEvent_load_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_event_SlackEvent_load_Method.prototype._getClass = slack_event_SlackEvent_load_Method__getClass;
 
@@ -51,14 +51,14 @@ function slack_event_SlackEvent_dispatch_Method__init_fields__() {
 slack_event_SlackEvent_dispatch_Method.prototype.__init_fields__ = slack_event_SlackEvent_dispatch_Method__init_fields__;
 
 function slack_event_SlackEvent_dispatch_Method_invoke(object, args) {
-    var obj = object;
-    (obj).dispatch((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.event.SlackEvent; });
+    (obj).dispatch(_qrt.cast((args)[0], function () { return slack.SlackHandler; }));
     return null;
 }
 slack_event_SlackEvent_dispatch_Method.prototype.invoke = slack_event_SlackEvent_dispatch_Method_invoke;
 
 function slack_event_SlackEvent_dispatch_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_event_SlackEvent_dispatch_Method.prototype._getClass = slack_event_SlackEvent_dispatch_Method__getClass;
 
@@ -93,7 +93,7 @@ function slack_event_SlackEvent_construct(args) {
 slack_event_SlackEvent.prototype.construct = slack_event_SlackEvent_construct;
 
 function slack_event_SlackEvent__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_event_SlackEvent.prototype._getClass = slack_event_SlackEvent__getClass;
 
@@ -120,14 +120,14 @@ function slack_event_SlackError_load_Method__init_fields__() {
 slack_event_SlackError_load_Method.prototype.__init_fields__ = slack_event_SlackError_load_Method__init_fields__;
 
 function slack_event_SlackError_load_Method_invoke(object, args) {
-    var obj = object;
-    (obj).load((args)[0], (args)[1]);
+    var obj = _qrt.cast(object, function () { return slack.event.SlackError; });
+    (obj).load(_qrt.cast((args)[0], function () { return slack.Client; }), _qrt.cast((args)[1], function () { return _qrt.JSONObject; }));
     return null;
 }
 slack_event_SlackError_load_Method.prototype.invoke = slack_event_SlackError_load_Method_invoke;
 
 function slack_event_SlackError_load_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_event_SlackError_load_Method.prototype._getClass = slack_event_SlackError_load_Method__getClass;
 
@@ -153,14 +153,14 @@ function slack_event_SlackError_dispatch_Method__init_fields__() {
 slack_event_SlackError_dispatch_Method.prototype.__init_fields__ = slack_event_SlackError_dispatch_Method__init_fields__;
 
 function slack_event_SlackError_dispatch_Method_invoke(object, args) {
-    var obj = object;
-    (obj).dispatch((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.event.SlackError; });
+    (obj).dispatch(_qrt.cast((args)[0], function () { return slack.SlackHandler; }));
     return null;
 }
 slack_event_SlackError_dispatch_Method.prototype.invoke = slack_event_SlackError_dispatch_Method_invoke;
 
 function slack_event_SlackError_dispatch_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_event_SlackError_dispatch_Method.prototype._getClass = slack_event_SlackError_dispatch_Method__getClass;
 
@@ -195,7 +195,7 @@ function slack_event_SlackError_construct(args) {
 slack_event_SlackError.prototype.construct = slack_event_SlackError_construct;
 
 function slack_event_SlackError__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_event_SlackError.prototype._getClass = slack_event_SlackError__getClass;
 
@@ -222,14 +222,14 @@ function slack_event_Hello_dispatch_Method__init_fields__() {
 slack_event_Hello_dispatch_Method.prototype.__init_fields__ = slack_event_Hello_dispatch_Method__init_fields__;
 
 function slack_event_Hello_dispatch_Method_invoke(object, args) {
-    var obj = object;
-    (obj).dispatch((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.event.Hello; });
+    (obj).dispatch(_qrt.cast((args)[0], function () { return slack.SlackHandler; }));
     return null;
 }
 slack_event_Hello_dispatch_Method.prototype.invoke = slack_event_Hello_dispatch_Method_invoke;
 
 function slack_event_Hello_dispatch_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_event_Hello_dispatch_Method.prototype._getClass = slack_event_Hello_dispatch_Method__getClass;
 
@@ -255,14 +255,14 @@ function slack_event_Hello_load_Method__init_fields__() {
 slack_event_Hello_load_Method.prototype.__init_fields__ = slack_event_Hello_load_Method__init_fields__;
 
 function slack_event_Hello_load_Method_invoke(object, args) {
-    var obj = object;
-    (obj).load((args)[0], (args)[1]);
+    var obj = _qrt.cast(object, function () { return slack.event.Hello; });
+    (obj).load(_qrt.cast((args)[0], function () { return slack.Client; }), _qrt.cast((args)[1], function () { return _qrt.JSONObject; }));
     return null;
 }
 slack_event_Hello_load_Method.prototype.invoke = slack_event_Hello_load_Method_invoke;
 
 function slack_event_Hello_load_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_event_Hello_load_Method.prototype._getClass = slack_event_Hello_load_Method__getClass;
 
@@ -297,7 +297,7 @@ function slack_event_Hello_construct(args) {
 slack_event_Hello.prototype.construct = slack_event_Hello_construct;
 
 function slack_event_Hello__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_event_Hello.prototype._getClass = slack_event_Hello__getClass;
 
@@ -324,14 +324,14 @@ function slack_event_Message_load_Method__init_fields__() {
 slack_event_Message_load_Method.prototype.__init_fields__ = slack_event_Message_load_Method__init_fields__;
 
 function slack_event_Message_load_Method_invoke(object, args) {
-    var obj = object;
-    (obj).load((args)[0], (args)[1]);
+    var obj = _qrt.cast(object, function () { return slack.event.Message; });
+    (obj).load(_qrt.cast((args)[0], function () { return slack.Client; }), _qrt.cast((args)[1], function () { return _qrt.JSONObject; }));
     return null;
 }
 slack_event_Message_load_Method.prototype.invoke = slack_event_Message_load_Method_invoke;
 
 function slack_event_Message_load_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_event_Message_load_Method.prototype._getClass = slack_event_Message_load_Method__getClass;
 
@@ -357,14 +357,14 @@ function slack_event_Message_dispatch_Method__init_fields__() {
 slack_event_Message_dispatch_Method.prototype.__init_fields__ = slack_event_Message_dispatch_Method__init_fields__;
 
 function slack_event_Message_dispatch_Method_invoke(object, args) {
-    var obj = object;
-    (obj).dispatch((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.event.Message; });
+    (obj).dispatch(_qrt.cast((args)[0], function () { return slack.SlackHandler; }));
     return null;
 }
 slack_event_Message_dispatch_Method.prototype.invoke = slack_event_Message_dispatch_Method_invoke;
 
 function slack_event_Message_dispatch_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_event_Message_dispatch_Method.prototype._getClass = slack_event_Message_dispatch_Method__getClass;
 
@@ -399,7 +399,7 @@ function slack_event_Message_construct(args) {
 slack_event_Message.prototype.construct = slack_event_Message_construct;
 
 function slack_event_Message__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_event_Message.prototype._getClass = slack_event_Message__getClass;
 
@@ -435,7 +435,7 @@ function slack_event_Edited_construct(args) {
 slack_event_Edited.prototype.construct = slack_event_Edited_construct;
 
 function slack_event_Edited__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_event_Edited.prototype._getClass = slack_event_Edited__getClass;
 
@@ -462,14 +462,14 @@ function slack_SlackHandler_onSlackEvent_Method__init_fields__() {
 slack_SlackHandler_onSlackEvent_Method.prototype.__init_fields__ = slack_SlackHandler_onSlackEvent_Method__init_fields__;
 
 function slack_SlackHandler_onSlackEvent_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onSlackEvent((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.SlackHandler; });
+    (obj).onSlackEvent(_qrt.cast((args)[0], function () { return slack.event.SlackEvent; }));
     return null;
 }
 slack_SlackHandler_onSlackEvent_Method.prototype.invoke = slack_SlackHandler_onSlackEvent_Method_invoke;
 
 function slack_SlackHandler_onSlackEvent_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_SlackHandler_onSlackEvent_Method.prototype._getClass = slack_SlackHandler_onSlackEvent_Method__getClass;
 
@@ -495,14 +495,14 @@ function slack_SlackHandler_onHello_Method__init_fields__() {
 slack_SlackHandler_onHello_Method.prototype.__init_fields__ = slack_SlackHandler_onHello_Method__init_fields__;
 
 function slack_SlackHandler_onHello_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onHello((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.SlackHandler; });
+    (obj).onHello(_qrt.cast((args)[0], function () { return slack.event.Hello; }));
     return null;
 }
 slack_SlackHandler_onHello_Method.prototype.invoke = slack_SlackHandler_onHello_Method_invoke;
 
 function slack_SlackHandler_onHello_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_SlackHandler_onHello_Method.prototype._getClass = slack_SlackHandler_onHello_Method__getClass;
 
@@ -528,14 +528,14 @@ function slack_SlackHandler_onSlackError_Method__init_fields__() {
 slack_SlackHandler_onSlackError_Method.prototype.__init_fields__ = slack_SlackHandler_onSlackError_Method__init_fields__;
 
 function slack_SlackHandler_onSlackError_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onSlackError((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.SlackHandler; });
+    (obj).onSlackError(_qrt.cast((args)[0], function () { return slack.event.SlackError; }));
     return null;
 }
 slack_SlackHandler_onSlackError_Method.prototype.invoke = slack_SlackHandler_onSlackError_Method_invoke;
 
 function slack_SlackHandler_onSlackError_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_SlackHandler_onSlackError_Method.prototype._getClass = slack_SlackHandler_onSlackError_Method__getClass;
 
@@ -561,14 +561,14 @@ function slack_SlackHandler_onMessage_Method__init_fields__() {
 slack_SlackHandler_onMessage_Method.prototype.__init_fields__ = slack_SlackHandler_onMessage_Method__init_fields__;
 
 function slack_SlackHandler_onMessage_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onMessage((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.SlackHandler; });
+    (obj).onMessage(_qrt.cast((args)[0], function () { return slack.event.Message; }));
     return null;
 }
 slack_SlackHandler_onMessage_Method.prototype.invoke = slack_SlackHandler_onMessage_Method_invoke;
 
 function slack_SlackHandler_onMessage_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_SlackHandler_onMessage_Method.prototype._getClass = slack_SlackHandler_onMessage_Method__getClass;
 
@@ -603,7 +603,7 @@ function slack_SlackHandler_construct(args) {
 slack_SlackHandler.prototype.construct = slack_SlackHandler_construct;
 
 function slack_SlackHandler__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_SlackHandler.prototype._getClass = slack_SlackHandler__getClass;
 
@@ -634,12 +634,12 @@ function slack_User__init_fields__() {
 slack_User.prototype.__init_fields__ = slack_User__init_fields__;
 slack_User.singleton = new slack_User();
 function slack_User_construct(args) {
-    return new slack.User((args)[0], (args)[1]);
+    return new slack.User(_qrt.cast((args)[0], function () { return slack.Client; }), _qrt.cast((args)[1], function () { return String; }));
 }
 slack_User.prototype.construct = slack_User_construct;
 
 function slack_User__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_User.prototype._getClass = slack_User__getClass;
 
@@ -666,14 +666,14 @@ function slack_Channel_send_Method__init_fields__() {
 slack_Channel_send_Method.prototype.__init_fields__ = slack_Channel_send_Method__init_fields__;
 
 function slack_Channel_send_Method_invoke(object, args) {
-    var obj = object;
-    (obj).send((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.Channel; });
+    (obj).send(_qrt.cast((args)[0], function () { return String; }));
     return null;
 }
 slack_Channel_send_Method.prototype.invoke = slack_Channel_send_Method_invoke;
 
 function slack_Channel_send_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Channel_send_Method.prototype._getClass = slack_Channel_send_Method__getClass;
 
@@ -703,12 +703,12 @@ function slack_Channel__init_fields__() {
 slack_Channel.prototype.__init_fields__ = slack_Channel__init_fields__;
 slack_Channel.singleton = new slack_Channel();
 function slack_Channel_construct(args) {
-    return new slack.Channel((args)[0], (args)[1]);
+    return new slack.Channel(_qrt.cast((args)[0], function () { return slack.Client; }), _qrt.cast((args)[1], function () { return String; }));
 }
 slack_Channel.prototype.construct = slack_Channel_construct;
 
 function slack_Channel__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Channel.prototype._getClass = slack_Channel__getClass;
 
@@ -735,14 +735,14 @@ function slack_Client_connect_Method__init_fields__() {
 slack_Client_connect_Method.prototype.__init_fields__ = slack_Client_connect_Method__init_fields__;
 
 function slack_Client_connect_Method_invoke(object, args) {
-    var obj = object;
+    var obj = _qrt.cast(object, function () { return slack.Client; });
     (obj).connect();
     return null;
 }
 slack_Client_connect_Method.prototype.invoke = slack_Client_connect_Method_invoke;
 
 function slack_Client_connect_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_connect_Method.prototype._getClass = slack_Client_connect_Method__getClass;
 
@@ -768,14 +768,14 @@ function slack_Client_request_Method__init_fields__() {
 slack_Client_request_Method.prototype.__init_fields__ = slack_Client_request_Method__init_fields__;
 
 function slack_Client_request_Method_invoke(object, args) {
-    var obj = object;
-    (obj).request((args)[0], (args)[1], (args)[2]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).request(_qrt.cast((args)[0], function () { return String; }), _qrt.cast((args)[1], function () { return Map; }), _qrt.cast((args)[2], function () { return quark.HTTPHandler; }));
     return null;
 }
 slack_Client_request_Method.prototype.invoke = slack_Client_request_Method_invoke;
 
 function slack_Client_request_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_request_Method.prototype._getClass = slack_Client_request_Method__getClass;
 
@@ -801,14 +801,14 @@ function slack_Client_ws_connect_Method__init_fields__() {
 slack_Client_ws_connect_Method.prototype.__init_fields__ = slack_Client_ws_connect_Method__init_fields__;
 
 function slack_Client_ws_connect_Method_invoke(object, args) {
-    var obj = object;
-    (obj).ws_connect((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).ws_connect(_qrt.cast((args)[0], function () { return String; }));
     return null;
 }
 slack_Client_ws_connect_Method.prototype.invoke = slack_Client_ws_connect_Method_invoke;
 
 function slack_Client_ws_connect_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_ws_connect_Method.prototype._getClass = slack_Client_ws_connect_Method__getClass;
 
@@ -834,14 +834,14 @@ function slack_Client_ws_send_Method__init_fields__() {
 slack_Client_ws_send_Method.prototype.__init_fields__ = slack_Client_ws_send_Method__init_fields__;
 
 function slack_Client_ws_send_Method_invoke(object, args) {
-    var obj = object;
-    (obj).ws_send((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).ws_send(_qrt.cast((args)[0], function () { return String; }));
     return null;
 }
 slack_Client_ws_send_Method.prototype.invoke = slack_Client_ws_send_Method_invoke;
 
 function slack_Client_ws_send_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_ws_send_Method.prototype._getClass = slack_Client_ws_send_Method__getClass;
 
@@ -867,14 +867,14 @@ function slack_Client_onWSConnected_Method__init_fields__() {
 slack_Client_onWSConnected_Method.prototype.__init_fields__ = slack_Client_onWSConnected_Method__init_fields__;
 
 function slack_Client_onWSConnected_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onWSConnected((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).onWSConnected(_qrt.cast((args)[0], function () { return quark.WebSocket; }));
     return null;
 }
 slack_Client_onWSConnected_Method.prototype.invoke = slack_Client_onWSConnected_Method_invoke;
 
 function slack_Client_onWSConnected_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_onWSConnected_Method.prototype._getClass = slack_Client_onWSConnected_Method__getClass;
 
@@ -900,14 +900,14 @@ function slack_Client_onWSClose_Method__init_fields__() {
 slack_Client_onWSClose_Method.prototype.__init_fields__ = slack_Client_onWSClose_Method__init_fields__;
 
 function slack_Client_onWSClose_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onWSClose((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).onWSClose(_qrt.cast((args)[0], function () { return quark.WebSocket; }));
     return null;
 }
 slack_Client_onWSClose_Method.prototype.invoke = slack_Client_onWSClose_Method_invoke;
 
 function slack_Client_onWSClose_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_onWSClose_Method.prototype._getClass = slack_Client_onWSClose_Method__getClass;
 
@@ -933,14 +933,14 @@ function slack_Client_onWSError_Method__init_fields__() {
 slack_Client_onWSError_Method.prototype.__init_fields__ = slack_Client_onWSError_Method__init_fields__;
 
 function slack_Client_onWSError_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onWSError((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).onWSError(_qrt.cast((args)[0], function () { return quark.WebSocket; }));
     return null;
 }
 slack_Client_onWSError_Method.prototype.invoke = slack_Client_onWSError_Method_invoke;
 
 function slack_Client_onWSError_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_onWSError_Method.prototype._getClass = slack_Client_onWSError_Method__getClass;
 
@@ -966,13 +966,13 @@ function slack_Client_construct_Method__init_fields__() {
 slack_Client_construct_Method.prototype.__init_fields__ = slack_Client_construct_Method__init_fields__;
 
 function slack_Client_construct_Method_invoke(object, args) {
-    var obj = object;
-    return (obj).construct((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    return (obj).construct(_qrt.cast((args)[0], function () { return String; }));
 }
 slack_Client_construct_Method.prototype.invoke = slack_Client_construct_Method_invoke;
 
 function slack_Client_construct_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_construct_Method.prototype._getClass = slack_Client_construct_Method__getClass;
 
@@ -998,14 +998,14 @@ function slack_Client_onWSMessage_Method__init_fields__() {
 slack_Client_onWSMessage_Method.prototype.__init_fields__ = slack_Client_onWSMessage_Method__init_fields__;
 
 function slack_Client_onWSMessage_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onWSMessage((args)[0], (args)[1]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).onWSMessage(_qrt.cast((args)[0], function () { return quark.WebSocket; }), _qrt.cast((args)[1], function () { return String; }));
     return null;
 }
 slack_Client_onWSMessage_Method.prototype.invoke = slack_Client_onWSMessage_Method_invoke;
 
 function slack_Client_onWSMessage_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_onWSMessage_Method.prototype._getClass = slack_Client_onWSMessage_Method__getClass;
 
@@ -1031,14 +1031,14 @@ function slack_Client_onHTTPResponse_Method__init_fields__() {
 slack_Client_onHTTPResponse_Method.prototype.__init_fields__ = slack_Client_onHTTPResponse_Method__init_fields__;
 
 function slack_Client_onHTTPResponse_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onHTTPResponse((args)[0], (args)[1]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).onHTTPResponse(_qrt.cast((args)[0], function () { return quark.HTTPRequest; }), _qrt.cast((args)[1], function () { return quark.HTTPResponse; }));
     return null;
 }
 slack_Client_onHTTPResponse_Method.prototype.invoke = slack_Client_onHTTPResponse_Method_invoke;
 
 function slack_Client_onHTTPResponse_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_onHTTPResponse_Method.prototype._getClass = slack_Client_onHTTPResponse_Method__getClass;
 
@@ -1064,14 +1064,14 @@ function slack_Client_onWSInit_Method__init_fields__() {
 slack_Client_onWSInit_Method.prototype.__init_fields__ = slack_Client_onWSInit_Method__init_fields__;
 
 function slack_Client_onWSInit_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onWSInit((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).onWSInit(_qrt.cast((args)[0], function () { return quark.WebSocket; }));
     return null;
 }
 slack_Client_onWSInit_Method.prototype.invoke = slack_Client_onWSInit_Method_invoke;
 
 function slack_Client_onWSInit_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_onWSInit_Method.prototype._getClass = slack_Client_onWSInit_Method__getClass;
 
@@ -1097,14 +1097,14 @@ function slack_Client_onWSBinary_Method__init_fields__() {
 slack_Client_onWSBinary_Method.prototype.__init_fields__ = slack_Client_onWSBinary_Method__init_fields__;
 
 function slack_Client_onWSBinary_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onWSBinary((args)[0], (args)[1]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).onWSBinary(_qrt.cast((args)[0], function () { return quark.WebSocket; }), (args)[1]);
     return null;
 }
 slack_Client_onWSBinary_Method.prototype.invoke = slack_Client_onWSBinary_Method_invoke;
 
 function slack_Client_onWSBinary_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_onWSBinary_Method.prototype._getClass = slack_Client_onWSBinary_Method__getClass;
 
@@ -1130,14 +1130,14 @@ function slack_Client_onWSClosed_Method__init_fields__() {
 slack_Client_onWSClosed_Method.prototype.__init_fields__ = slack_Client_onWSClosed_Method__init_fields__;
 
 function slack_Client_onWSClosed_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onWSClosed((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).onWSClosed(_qrt.cast((args)[0], function () { return quark.WebSocket; }));
     return null;
 }
 slack_Client_onWSClosed_Method.prototype.invoke = slack_Client_onWSClosed_Method_invoke;
 
 function slack_Client_onWSClosed_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_onWSClosed_Method.prototype._getClass = slack_Client_onWSClosed_Method__getClass;
 
@@ -1163,14 +1163,14 @@ function slack_Client_onWSFinal_Method__init_fields__() {
 slack_Client_onWSFinal_Method.prototype.__init_fields__ = slack_Client_onWSFinal_Method__init_fields__;
 
 function slack_Client_onWSFinal_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onWSFinal((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).onWSFinal(_qrt.cast((args)[0], function () { return quark.WebSocket; }));
     return null;
 }
 slack_Client_onWSFinal_Method.prototype.invoke = slack_Client_onWSFinal_Method_invoke;
 
 function slack_Client_onWSFinal_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_onWSFinal_Method.prototype._getClass = slack_Client_onWSFinal_Method__getClass;
 
@@ -1196,14 +1196,14 @@ function slack_Client_onHTTPInit_Method__init_fields__() {
 slack_Client_onHTTPInit_Method.prototype.__init_fields__ = slack_Client_onHTTPInit_Method__init_fields__;
 
 function slack_Client_onHTTPInit_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onHTTPInit((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).onHTTPInit(_qrt.cast((args)[0], function () { return quark.HTTPRequest; }));
     return null;
 }
 slack_Client_onHTTPInit_Method.prototype.invoke = slack_Client_onHTTPInit_Method_invoke;
 
 function slack_Client_onHTTPInit_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_onHTTPInit_Method.prototype._getClass = slack_Client_onHTTPInit_Method__getClass;
 
@@ -1229,14 +1229,14 @@ function slack_Client_onHTTPError_Method__init_fields__() {
 slack_Client_onHTTPError_Method.prototype.__init_fields__ = slack_Client_onHTTPError_Method__init_fields__;
 
 function slack_Client_onHTTPError_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onHTTPError((args)[0], (args)[1]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).onHTTPError(_qrt.cast((args)[0], function () { return quark.HTTPRequest; }), _qrt.cast((args)[1], function () { return String; }));
     return null;
 }
 slack_Client_onHTTPError_Method.prototype.invoke = slack_Client_onHTTPError_Method_invoke;
 
 function slack_Client_onHTTPError_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_onHTTPError_Method.prototype._getClass = slack_Client_onHTTPError_Method__getClass;
 
@@ -1262,14 +1262,14 @@ function slack_Client_onHTTPFinal_Method__init_fields__() {
 slack_Client_onHTTPFinal_Method.prototype.__init_fields__ = slack_Client_onHTTPFinal_Method__init_fields__;
 
 function slack_Client_onHTTPFinal_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onHTTPFinal((args)[0]);
+    var obj = _qrt.cast(object, function () { return slack.Client; });
+    (obj).onHTTPFinal(_qrt.cast((args)[0], function () { return quark.HTTPRequest; }));
     return null;
 }
 slack_Client_onHTTPFinal_Method.prototype.invoke = slack_Client_onHTTPFinal_Method_invoke;
 
 function slack_Client_onHTTPFinal_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client_onHTTPFinal_Method.prototype._getClass = slack_Client_onHTTPFinal_Method__getClass;
 
@@ -1299,12 +1299,12 @@ function slack_Client__init_fields__() {
 slack_Client.prototype.__init_fields__ = slack_Client__init_fields__;
 slack_Client.singleton = new slack_Client();
 function slack_Client_construct(args) {
-    return new slack.Client((args)[0], (args)[1], (args)[2]);
+    return new slack.Client(_qrt.cast((args)[0], function () { return quark.Runtime; }), _qrt.cast((args)[1], function () { return String; }), _qrt.cast((args)[2], function () { return slack.SlackHandler; }));
 }
 slack_Client.prototype.construct = slack_Client_construct;
 
 function slack_Client__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slack_Client.prototype._getClass = slack_Client__getClass;
 
@@ -1331,14 +1331,14 @@ function slackpack_Handler_onSlackEvent_Method__init_fields__() {
 slackpack_Handler_onSlackEvent_Method.prototype.__init_fields__ = slackpack_Handler_onSlackEvent_Method__init_fields__;
 
 function slackpack_Handler_onSlackEvent_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onSlackEvent((args)[0]);
+    var obj = _qrt.cast(object, function () { return slackpack.Handler; });
+    (obj).onSlackEvent(_qrt.cast((args)[0], function () { return slack.event.SlackEvent; }));
     return null;
 }
 slackpack_Handler_onSlackEvent_Method.prototype.invoke = slackpack_Handler_onSlackEvent_Method_invoke;
 
 function slackpack_Handler_onSlackEvent_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slackpack_Handler_onSlackEvent_Method.prototype._getClass = slackpack_Handler_onSlackEvent_Method__getClass;
 
@@ -1364,14 +1364,14 @@ function slackpack_Handler_onHello_Method__init_fields__() {
 slackpack_Handler_onHello_Method.prototype.__init_fields__ = slackpack_Handler_onHello_Method__init_fields__;
 
 function slackpack_Handler_onHello_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onHello((args)[0]);
+    var obj = _qrt.cast(object, function () { return slackpack.Handler; });
+    (obj).onHello(_qrt.cast((args)[0], function () { return slack.event.Hello; }));
     return null;
 }
 slackpack_Handler_onHello_Method.prototype.invoke = slackpack_Handler_onHello_Method_invoke;
 
 function slackpack_Handler_onHello_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slackpack_Handler_onHello_Method.prototype._getClass = slackpack_Handler_onHello_Method__getClass;
 
@@ -1397,14 +1397,14 @@ function slackpack_Handler_onSlackError_Method__init_fields__() {
 slackpack_Handler_onSlackError_Method.prototype.__init_fields__ = slackpack_Handler_onSlackError_Method__init_fields__;
 
 function slackpack_Handler_onSlackError_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onSlackError((args)[0]);
+    var obj = _qrt.cast(object, function () { return slackpack.Handler; });
+    (obj).onSlackError(_qrt.cast((args)[0], function () { return slack.event.SlackError; }));
     return null;
 }
 slackpack_Handler_onSlackError_Method.prototype.invoke = slackpack_Handler_onSlackError_Method_invoke;
 
 function slackpack_Handler_onSlackError_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slackpack_Handler_onSlackError_Method.prototype._getClass = slackpack_Handler_onSlackError_Method__getClass;
 
@@ -1430,14 +1430,14 @@ function slackpack_Handler_onMessage_Method__init_fields__() {
 slackpack_Handler_onMessage_Method.prototype.__init_fields__ = slackpack_Handler_onMessage_Method__init_fields__;
 
 function slackpack_Handler_onMessage_Method_invoke(object, args) {
-    var obj = object;
-    (obj).onMessage((args)[0]);
+    var obj = _qrt.cast(object, function () { return slackpack.Handler; });
+    (obj).onMessage(_qrt.cast((args)[0], function () { return slack.event.Message; }));
     return null;
 }
 slackpack_Handler_onMessage_Method.prototype.invoke = slackpack_Handler_onMessage_Method_invoke;
 
 function slackpack_Handler_onMessage_Method__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slackpack_Handler_onMessage_Method.prototype._getClass = slackpack_Handler_onMessage_Method__getClass;
 
@@ -1472,7 +1472,7 @@ function slackpack_Handler_construct(args) {
 slackpack_Handler.prototype.construct = slackpack_Handler_construct;
 
 function slackpack_Handler__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 slackpack_Handler.prototype._getClass = slackpack_Handler__getClass;
 
@@ -1508,7 +1508,7 @@ function quark_Map_quark_String_quark_Object__construct(args) {
 quark_Map_quark_String_quark_Object_.prototype.construct = quark_Map_quark_String_quark_Object__construct;
 
 function quark_Map_quark_String_quark_Object___getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 quark_Map_quark_String_quark_Object_.prototype._getClass = quark_Map_quark_String_quark_Object___getClass;
 
@@ -1541,7 +1541,7 @@ Root.slack_Client_md = slack_Client.singleton;
 Root.slackpack_Handler_md = slackpack_Handler.singleton;
 Root.quark_Map_quark_String_quark_Object__md = quark_Map_quark_String_quark_Object_.singleton;
 function Root__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 Root.prototype._getClass = Root__getClass;
 

--- a/quarkc/test/ffi/expected/js/test/testlib/index.js
+++ b/quarkc/test/ffi/expected/js/test/testlib/index.js
@@ -2,11 +2,11 @@ var _qrt = require("quark/quark_runtime.js");
 
 
 function atest() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 exports.atest = atest;
 
 function foo() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 exports.foo = foo;

--- a/quarkc/test/ffi/expected/js/test/testlib_md/index.js
+++ b/quarkc/test/ffi/expected/js/test/testlib_md/index.js
@@ -11,7 +11,7 @@ function Root__init_fields__() {}
 Root.prototype.__init_fields__ = Root__init_fields__;
 
 function Root__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 Root.prototype._getClass = Root__getClass;
 

--- a/quarkc/test/ffi/expected/js/use/puse_md/index.js
+++ b/quarkc/test/ffi/expected/js/use/puse_md/index.js
@@ -11,7 +11,7 @@ function Root__init_fields__() {}
 Root.prototype.__init_fields__ = Root__init_fields__;
 
 function Root__getClass() {
-    return null;
+    return _qrt.cast(null, function () { return String; });
 }
 Root.prototype._getClass = Root__getClass;
 

--- a/quarkc/test/ffi/expected/py/dependencies/dependencies_md/__init__.py
+++ b/quarkc/test/ffi/expected/py/dependencies/dependencies_md/__init__.py
@@ -7,7 +7,7 @@ class Root(object):
     def __init__(self): self._init()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None

--- a/quarkc/test/ffi/expected/py/org_example_foo/org_example_foo_md/__init__.py
+++ b/quarkc/test/ffi/expected/py/org_example_foo/org_example_foo_md/__init__.py
@@ -11,12 +11,12 @@ class org_example_foo_Foo_test_Method(quark.reflect.Method):
         super(org_example_foo_Foo_test_Method, self).__init__(u"quark.void", u"test", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: org.example.foo.Foo);
         (obj).test();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -39,7 +39,7 @@ class org_example_foo_Foo(quark.reflect.Class):
         return org.example.foo.Foo()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -54,7 +54,7 @@ class Root(object):
     def __init__(self): self._init()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None

--- a/quarkc/test/ffi/expected/py/overlapping_namespaces/overlapping_namespace_md/__init__.py
+++ b/quarkc/test/ffi/expected/py/overlapping_namespaces/overlapping_namespace_md/__init__.py
@@ -11,12 +11,12 @@ class org_example_bar_Bar_test_Method(quark.reflect.Method):
         super(org_example_bar_Bar_test_Method, self).__init__(u"quark.void", u"test", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: org.example.bar.Bar);
         (obj).test();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -39,7 +39,7 @@ class org_example_bar_Bar(quark.reflect.Class):
         return org.example.bar.Bar()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -54,7 +54,7 @@ class Root(object):
     def __init__(self): self._init()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None

--- a/quarkc/test/ffi/expected/py/package/package_md/__init__.py
+++ b/quarkc/test/ffi/expected/py/package/package_md/__init__.py
@@ -11,12 +11,12 @@ class test_Test_go_Method(quark.reflect.Method):
         super(test_Test_go_Method, self).__init__(u"quark.void", u"go", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: test.Test);
         (obj).go();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -39,7 +39,7 @@ class test_Test(quark.reflect.Class):
         return test.Test()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -56,12 +56,12 @@ class test_subtest_Test_go_Method(quark.reflect.Method):
         super(test_subtest_Test_go_Method, self).__init__(u"quark.void", u"go", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: test.subtest.Test);
         (obj).go();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -84,7 +84,7 @@ class test_subtest_Test(quark.reflect.Class):
         return test.subtest.Test()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -99,7 +99,7 @@ class Root(object):
     def __init__(self): self._init()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None

--- a/quarkc/test/ffi/expected/py/package/test/__init__.py
+++ b/quarkc/test/ffi/expected/py/package/test/__init__.py
@@ -28,7 +28,7 @@ class Test(object):
 
     def _setField(self, name, value):
         if ((name) == (u"name")):
-            (self).name = value
+            (self).name = _cast(value, lambda: unicode)
 
 
 Test.test_Test_ref = package_md.Root.test_Test_md

--- a/quarkc/test/ffi/expected/py/package/test/subtest/__init__.py
+++ b/quarkc/test/ffi/expected/py/package/test/subtest/__init__.py
@@ -27,7 +27,7 @@ class Test(object):
 
     def _setField(self, name, value):
         if ((name) == (u"size")):
-            (self).size = value
+            (self).size = _cast(value, lambda: int)
 
 
 Test.test_subtest_Test_ref = package_md.Root.test_subtest_Test_md

--- a/quarkc/test/ffi/expected/py/signatures/classes/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/classes/__init__.py
@@ -13,10 +13,10 @@ class Overload(object):
         self._init()
 
     def __add__(self, o):
-        return None
+        return _cast(None, lambda: Overload)
 
     def __mul__(self, o):
-        return None
+        return _cast(None, lambda: Overload)
 
     def test(self):
         pass
@@ -32,7 +32,7 @@ class Overload(object):
 
     def _setField(self, name, value):
         if ((name) == (u"name")):
-            (self).name = value
+            (self).name = _cast(value, lambda: unicode)
 
 
 Overload.classes_Overload_ref = quark_ffi_signatures_md.Root.classes_Overload_md
@@ -79,7 +79,7 @@ class test_size(string_test):
         super(test_size, self).__init__();
 
     def does(self, expected):
-        return None
+        return _cast(None, lambda: test_size)
 
     def _getClass(self):
         return u"classes.test_size"
@@ -92,7 +92,7 @@ class test_size(string_test):
 
     def _setField(self, name, value):
         if ((name) == (u"what")):
-            (self).what = value
+            (self).what = _cast(value, lambda: unicode)
 
 
 test_size.classes_test_size_ref = quark_ffi_signatures_md.Root.classes_test_size_md
@@ -106,10 +106,10 @@ class test_startsWith(string_test):
         super(test_startsWith, self).__init__();
 
     def that(self, _that):
-        return None
+        return _cast(None, lambda: test_startsWith)
 
     def does(self, expected):
-        return None
+        return _cast(None, lambda: test_startsWith)
 
     def _getClass(self):
         return u"classes.test_startsWith"
@@ -125,10 +125,10 @@ class test_startsWith(string_test):
 
     def _setField(self, name, value):
         if ((name) == (u"what")):
-            (self).what = value
+            (self).what = _cast(value, lambda: unicode)
 
         if ((name) == (u"_that")):
-            (self)._that = value
+            (self)._that = _cast(value, lambda: unicode)
 
 
 test_startsWith.classes_test_startsWith_ref = quark_ffi_signatures_md.Root.classes_test_startsWith_md
@@ -142,10 +142,10 @@ class test_endsWith(string_test):
         super(test_endsWith, self).__init__();
 
     def that(self, _that):
-        return None
+        return _cast(None, lambda: test_endsWith)
 
     def does(self, expected):
-        return None
+        return _cast(None, lambda: test_endsWith)
 
     def _getClass(self):
         return u"classes.test_endsWith"
@@ -161,10 +161,10 @@ class test_endsWith(string_test):
 
     def _setField(self, name, value):
         if ((name) == (u"what")):
-            (self).what = value
+            (self).what = _cast(value, lambda: unicode)
 
         if ((name) == (u"_that")):
-            (self)._that = value
+            (self)._that = _cast(value, lambda: unicode)
 
 
 test_endsWith.classes_test_endsWith_ref = quark_ffi_signatures_md.Root.classes_test_endsWith_md
@@ -178,10 +178,10 @@ class test_find(string_test):
         super(test_find, self).__init__();
 
     def that(self, _that):
-        return None
+        return _cast(None, lambda: test_find)
 
     def does(self, expected):
-        return None
+        return _cast(None, lambda: test_find)
 
     def _getClass(self):
         return u"classes.test_find"
@@ -197,10 +197,10 @@ class test_find(string_test):
 
     def _setField(self, name, value):
         if ((name) == (u"what")):
-            (self).what = value
+            (self).what = _cast(value, lambda: unicode)
 
         if ((name) == (u"_that")):
-            (self)._that = value
+            (self)._that = _cast(value, lambda: unicode)
 
 
 test_find.classes_test_find_ref = quark_ffi_signatures_md.Root.classes_test_find_md
@@ -215,10 +215,10 @@ class test_substring(string_test):
         super(test_substring, self).__init__();
 
     def that(self, start, end):
-        return None
+        return _cast(None, lambda: test_substring)
 
     def does(self, expected):
-        return None
+        return _cast(None, lambda: test_substring)
 
     def _getClass(self):
         return u"classes.test_substring"
@@ -237,13 +237,13 @@ class test_substring(string_test):
 
     def _setField(self, name, value):
         if ((name) == (u"what")):
-            (self).what = value
+            (self).what = _cast(value, lambda: unicode)
 
         if ((name) == (u"start")):
-            (self).start = value
+            (self).start = _cast(value, lambda: int)
 
         if ((name) == (u"end")):
-            (self).end = value
+            (self).end = _cast(value, lambda: int)
 
 
 test_substring.classes_test_substring_ref = quark_ffi_signatures_md.Root.classes_test_substring_md
@@ -258,10 +258,10 @@ class test_replace(string_test):
         super(test_replace, self).__init__();
 
     def that(self, start, end):
-        return None
+        return _cast(None, lambda: test_replace)
 
     def does(self, expected):
-        return None
+        return _cast(None, lambda: test_replace)
 
     def _getClass(self):
         return u"classes.test_replace"
@@ -280,13 +280,13 @@ class test_replace(string_test):
 
     def _setField(self, name, value):
         if ((name) == (u"what")):
-            (self).what = value
+            (self).what = _cast(value, lambda: unicode)
 
         if ((name) == (u"start")):
-            (self).start = value
+            (self).start = _cast(value, lambda: unicode)
 
         if ((name) == (u"end")):
-            (self).end = value
+            (self).end = _cast(value, lambda: unicode)
 
 
 test_replace.classes_test_replace_ref = quark_ffi_signatures_md.Root.classes_test_replace_md
@@ -302,13 +302,13 @@ class test_join(string_test):
         super(test_join, self).__init__();
 
     def that(self):
-        return None
+        return _cast(None, lambda: test_join)
 
     def a(self, part):
-        return None
+        return _cast(None, lambda: test_join)
 
     def does(self, expected):
-        return None
+        return _cast(None, lambda: test_join)
 
     def _getClass(self):
         return u"classes.test_join"
@@ -330,16 +330,16 @@ class test_join(string_test):
 
     def _setField(self, name, value):
         if ((name) == (u"what")):
-            (self).what = value
+            (self).what = _cast(value, lambda: unicode)
 
         if ((name) == (u"parts")):
-            (self).parts = value
+            (self).parts = _cast(value, lambda: _List)
 
         if ((name) == (u"strparts")):
-            (self).strparts = value
+            (self).strparts = _cast(value, lambda: unicode)
 
         if ((name) == (u"sep")):
-            (self).sep = value
+            (self).sep = _cast(value, lambda: unicode)
 
 
 test_join.classes_test_join_ref = quark_ffi_signatures_md.Root.classes_test_join_md
@@ -354,10 +354,10 @@ class test_split(string_test):
         super(test_split, self).__init__();
 
     def that(self, what):
-        return None
+        return _cast(None, lambda: test_split)
 
     def does(self, expected):
-        return None
+        return _cast(None, lambda: test_split)
 
     def _getClass(self):
         return u"classes.test_split"
@@ -376,13 +376,13 @@ class test_split(string_test):
 
     def _setField(self, name, value):
         if ((name) == (u"what")):
-            (self).what = value
+            (self).what = _cast(value, lambda: unicode)
 
         if ((name) == (u"sep")):
-            (self).sep = value
+            (self).sep = _cast(value, lambda: unicode)
 
         if ((name) == (u"altsep")):
-            (self).altsep = value
+            (self).altsep = _cast(value, lambda: unicode)
 
 
 test_split.classes_test_split_ref = quark_ffi_signatures_md.Root.classes_test_split_md

--- a/quarkc/test/ffi/expected/py/signatures/classes/stuff/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/classes/stuff/__init__.py
@@ -10,7 +10,7 @@ class Test(object):
     def __init__(self): self._init()
 
     def foo(self, t):
-        return None
+        return _cast(None, lambda: Test)
 
     def test(self):
         pass

--- a/quarkc/test/ffi/expected/py/signatures/docs/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/docs/__init__.py
@@ -32,7 +32,7 @@ class Test(object):
 
     def _setField(self, name, value):
         if ((name) == (u"name")):
-            (self).name = value
+            (self).name = _cast(value, lambda: unicode)
 
 
 Test.docs_Test_ref = quark_ffi_signatures_md.Root.docs_Test_md

--- a/quarkc/test/ffi/expected/py/signatures/functions/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/functions/__init__.py
@@ -3,4 +3,4 @@ from quark_runtime import *
 
 
 def factorial(n):
-    return None
+    return _cast(None, lambda: int)

--- a/quarkc/test/ffi/expected/py/signatures/generics/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/generics/__init__.py
@@ -17,7 +17,7 @@ class Box(object):
         pass
 
     def get(self):
-        return None
+        return _cast(None, lambda: T)
 
     def _getClass(self):
         return u"generics.Box<quark.Object>"
@@ -30,7 +30,7 @@ class Box(object):
 
     def _setField(self, name, value):
         if ((name) == (u"contents")):
-            (self).contents = value
+            (self).contents = _cast(value, lambda: T)
 
 
 
@@ -45,7 +45,7 @@ class Crate(object):
         pass
 
     def get(self):
-        return None
+        return _cast(None, lambda: T)
 
     def _getClass(self):
         return u"generics.Crate<quark.Object>"
@@ -61,10 +61,10 @@ class Crate(object):
 
     def _setField(self, name, value):
         if ((name) == (u"box")):
-            (self).box = value
+            (self).box = _cast(value, lambda: Box)
 
         if ((name) == (u"ibox")):
-            (self).ibox = value
+            (self).ibox = _cast(value, lambda: Box)
 
 
 Crate.generics_Box_quark_Object__ref = quark_ffi_signatures_md.Root.generics_Box_quark_Object__md
@@ -87,7 +87,7 @@ class Sack(object):
 
     def _setField(self, name, value):
         if ((name) == (u"ints")):
-            (self).ints = value
+            (self).ints = _cast(value, lambda: Box)
 
 
 Sack.generics_Sack_ref = quark_ffi_signatures_md.Root.generics_Sack_md
@@ -101,7 +101,7 @@ class Matrix(object):
         self._init()
 
     def _q__get__(self, i, j):
-        return None
+        return _cast(None, lambda: T)
 
     def _q__set__(self, i, j, value):
         pass
@@ -123,13 +123,13 @@ class Matrix(object):
 
     def _setField(self, name, value):
         if ((name) == (u"width")):
-            (self).width = value
+            (self).width = _cast(value, lambda: int)
 
         if ((name) == (u"height")):
-            (self).height = value
+            (self).height = _cast(value, lambda: int)
 
         if ((name) == (u"columns")):
-            (self).columns = value
+            (self).columns = _cast(value, lambda: _List)
 
 
 Matrix.generics_Matrix_quark_Object__ref = quark_ffi_signatures_md.Root.generics_Matrix_quark_Object__md

--- a/quarkc/test/ffi/expected/py/signatures/generics/ccc/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/generics/ccc/__init__.py
@@ -10,7 +10,7 @@ class TLSContextInitializer(object):
     def __init__(self): self._init()
 
     def getValue(self):
-        return None
+        return _cast(None, lambda: Context)
 
     def _getClass(self):
         return u"generics.ccc.TLSContextInitializer"
@@ -30,11 +30,11 @@ class Context(object):
 
     @staticmethod
     def current():
-        return None
+        return _cast(None, lambda: Context)
 
     @staticmethod
     def global_():
-        return None
+        return _cast(None, lambda: Context)
 
     def _getClass(self):
         return u"generics.ccc.Context"
@@ -53,13 +53,13 @@ class Context(object):
 
     def _setField(self, name, value):
         if ((name) == (u"_global")):
-            Context._global = value
+            Context._global = _cast(value, lambda: Context)
 
         if ((name) == (u"_current")):
-            Context._current = value
+            Context._current = _cast(value, lambda: TLS)
 
         if ((name) == (u"parent")):
-            (self).parent = value
+            (self).parent = _cast(value, lambda: Context)
 
 
 Context._global = None
@@ -69,7 +69,7 @@ Context.generics_ccc_TLS_generics_ccc_Context__ref = quark_ffi_signatures_md.Roo
 class TLSInitializer(object):
 
     def getValue(self):
-        assert False
+        raise NotImplementedError('`TLSInitializer.getValue` is an abstract method')
 
 TLSInitializer.generics_ccc_TLSInitializer_quark_Object__ref = quark_ffi_signatures_md.Root.generics_ccc_TLSInitializer_quark_Object__md
 class TLS(object):
@@ -80,7 +80,7 @@ class TLS(object):
         self._init()
 
     def getValue(self):
-        return None
+        return _cast(None, lambda: T)
 
     def _getClass(self):
         return u"generics.ccc.TLS<quark.Object>"
@@ -93,6 +93,6 @@ class TLS(object):
 
     def _setField(self, name, value):
         if ((name) == (u"_value")):
-            (self)._value = value
+            (self)._value = _cast(value, lambda: T)
 
 

--- a/quarkc/test/ffi/expected/py/signatures/generics/constructors/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/generics/constructors/__init__.py
@@ -12,7 +12,7 @@ class Box(object):
         self._init()
 
     def get(self):
-        return None
+        return _cast(None, lambda: T)
 
     def _getClass(self):
         return u"generics.constructors.Box<quark.Object>"
@@ -25,7 +25,7 @@ class Box(object):
 
     def _setField(self, name, value):
         if ((name) == (u"contents")):
-            (self).contents = value
+            (self).contents = _cast(value, lambda: T)
 
 
 Box.generics_constructors_Box_quark_Object__ref = quark_ffi_signatures_md.Root.generics_constructors_Box_quark_Object__md

--- a/quarkc/test/ffi/expected/py/signatures/generics/pkg/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/generics/pkg/__init__.py
@@ -7,10 +7,10 @@ import quark_ffi_signatures_md
 class Foo(object):
 
     def foo(self):
-        return None
+        return _cast(None, lambda: T)
 
     def get(self):
-        assert False
+        raise NotImplementedError('`Foo.get` is an abstract method')
 
 Foo.generics_pkg_Foo_quark_Object__ref = quark_ffi_signatures_md.Root.generics_pkg_Foo_quark_Object__md
 class StringFoo(object):
@@ -19,7 +19,7 @@ class StringFoo(object):
     def __init__(self): self._init()
 
     def get(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getClass(self):
         return u"generics.pkg.StringFoo"
@@ -31,7 +31,7 @@ class StringFoo(object):
         pass
 
     def foo(self):
-        return None
+        return _cast(None, lambda: unicode)
 
 StringFoo.generics_pkg_StringFoo_ref = quark_ffi_signatures_md.Root.generics_pkg_StringFoo_md
 class Box(object):
@@ -52,7 +52,7 @@ class Box(object):
 
     def _setField(self, name, value):
         if ((name) == (u"contents")):
-            (self).contents = value
+            (self).contents = _cast(value, lambda: T)
 
 
 
@@ -74,7 +74,7 @@ class StringBox(Box):
 
     def _setField(self, name, value):
         if ((name) == (u"contents")):
-            (self).contents = value
+            (self).contents = _cast(value, lambda: unicode)
 
 
 StringBox.generics_pkg_Box_quark_String__ref = quark_ffi_signatures_md.Root.generics_pkg_Box_quark_String__md

--- a/quarkc/test/ffi/expected/py/signatures/inheritance/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/inheritance/__init__.py
@@ -26,7 +26,7 @@ class Base(object):
 
     def _setField(self, name, value):
         if ((name) == (u"name")):
-            (self).name = value
+            (self).name = _cast(value, lambda: unicode)
 
 
 Base.inheritance_Base_ref = quark_ffi_signatures_md.Root.inheritance_Base_md
@@ -56,13 +56,13 @@ class Test(Base):
 
     def _setField(self, name, value):
         if ((name) == (u"name")):
-            (self).name = value
+            (self).name = _cast(value, lambda: unicode)
 
         if ((name) == (u"mumble")):
-            (self).mumble = value
+            (self).mumble = _cast(value, lambda: unicode)
 
         if ((name) == (u"later")):
-            (self).later = value
+            (self).later = _cast(value, lambda: unicode)
 
 
 Test.inheritance_Test_ref = quark_ffi_signatures_md.Root.inheritance_Test_md
@@ -84,7 +84,7 @@ class A(object):
 
     def _setField(self, name, value):
         if ((name) == (u"name")):
-            (self).name = value
+            (self).name = _cast(value, lambda: unicode)
 
 
 A.inheritance_A_ref = quark_ffi_signatures_md.Root.inheritance_A_md
@@ -109,7 +109,7 @@ class B(A):
 
     def _setField(self, name, value):
         if ((name) == (u"name")):
-            (self).name = value
+            (self).name = _cast(value, lambda: unicode)
 
 
 B.inheritance_B_ref = quark_ffi_signatures_md.Root.inheritance_B_md
@@ -134,7 +134,7 @@ class C(A):
 
     def _setField(self, name, value):
         if ((name) == (u"name")):
-            (self).name = value
+            (self).name = _cast(value, lambda: unicode)
 
 
 C.inheritance_C_ref = quark_ffi_signatures_md.Root.inheritance_C_md
@@ -174,7 +174,7 @@ class Y(X):
 
     def _setField(self, name, value):
         if ((name) == (u"name")):
-            (self).name = value
+            (self).name = _cast(value, lambda: unicode)
 
 
 Y.inheritance_Y_ref = quark_ffi_signatures_md.Root.inheritance_Y_md
@@ -184,7 +184,7 @@ class Message(object):
     def __init__(self): self._init()
 
     def encode(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getClass(self):
         return u"inheritance.Message"
@@ -219,7 +219,7 @@ class Pong(Message):
         super(Pong, self).__init__();
 
     def toString(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getClass(self):
         return u"inheritance.Pong"

--- a/quarkc/test/ffi/expected/py/signatures/inheritance/pets/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/inheritance/pets/__init__.py
@@ -10,7 +10,7 @@ class Pet(object):
     def __init__(self): self._init()
 
     def greet(self):
-        assert False
+        raise NotImplementedError('`Pet.greet` is an abstract method')
 
 class Cat(Pet):
     def _init(self):

--- a/quarkc/test/ffi/expected/py/signatures/inheritance/super_/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/inheritance/super_/__init__.py
@@ -25,7 +25,7 @@ class A(object):
 
     def _setField(self, name, value):
         if ((name) == (u"name")):
-            (self).name = value
+            (self).name = _cast(value, lambda: unicode)
 
 
 A.inheritance_super__A_ref = quark_ffi_signatures_md.Root.inheritance_super__A_md
@@ -50,7 +50,7 @@ class B(A):
 
     def _setField(self, name, value):
         if ((name) == (u"name")):
-            (self).name = value
+            (self).name = _cast(value, lambda: unicode)
 
 
 B.inheritance_super__B_ref = quark_ffi_signatures_md.Root.inheritance_super__B_md

--- a/quarkc/test/ffi/expected/py/signatures/inheritance/use_before_def/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/inheritance/use_before_def/__init__.py
@@ -38,7 +38,7 @@ class Foo(object):
 
     def _setField(self, name, value):
         if ((name) == (u"name")):
-            (self).name = value
+            (self).name = _cast(value, lambda: unicode)
 
 
 Foo.inheritance_use_before_def_Foo_ref = quark_ffi_signatures_md.Root.inheritance_use_before_def_Foo_md

--- a/quarkc/test/ffi/expected/py/signatures/interfaces/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/interfaces/__init__.py
@@ -7,7 +7,7 @@ import quark_ffi_signatures_md
 class A(object):
 
     def foo(self):
-        assert False
+        raise NotImplementedError('`A.foo` is an abstract method')
 
     def bar(self):
         pass
@@ -128,26 +128,26 @@ T5.interfaces_T5_ref = quark_ffi_signatures_md.Root.interfaces_T5_md
 class Foo(object):
 
     def m1(self):
-        assert False
+        raise NotImplementedError('`Foo.m1` is an abstract method')
 
     def m2(self, arg):
-        assert False
+        raise NotImplementedError('`Foo.m2` is an abstract method')
 
     def m3(self, args):
-        assert False
+        raise NotImplementedError('`Foo.m3` is an abstract method')
 
 Foo.interfaces_Foo_ref = quark_ffi_signatures_md.Root.interfaces_Foo_md
 Foo.quark_List_quark_String__ref = quark_ffi_signatures_md.Root.quark_List_quark_String__md
 class Bar(object):
 
     def m1(self):
-        assert False
+        raise NotImplementedError('`Bar.m1` is an abstract method')
 
     def m2(self, arg):
-        assert False
+        raise NotImplementedError('`Bar.m2` is an abstract method')
 
     def m3(self, args):
-        assert False
+        raise NotImplementedError('`Bar.m3` is an abstract method')
 
 Bar.interfaces_Bar_quark_Object__ref = quark_ffi_signatures_md.Root.interfaces_Bar_quark_Object__md
 class Baz(object):

--- a/quarkc/test/ffi/expected/py/signatures/quark_ffi_signatures_md/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/quark_ffi_signatures_md/__init__.py
@@ -11,12 +11,12 @@ class generics_Box_quark_Object__set_Method(quark.reflect.Method):
         super(generics_Box_quark_Object__set_Method, self).__init__(u"quark.void", u"set", _List([u"quark.Object"]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.Box);
         (obj).set((args)[0]);
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -32,11 +32,11 @@ class generics_Box_quark_Object__get_Method(quark.reflect.Method):
         super(generics_Box_quark_Object__get_Method, self).__init__(u"quark.Object", u"get", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.Box);
         return (obj).get()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -59,7 +59,7 @@ class generics_Box_quark_Object_(quark.reflect.Class):
         return generics.Box()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -76,12 +76,12 @@ class generics_Box_quark_int__set_Method(quark.reflect.Method):
         super(generics_Box_quark_int__set_Method, self).__init__(u"quark.void", u"set", _List([u"quark.int"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).set((args)[0]);
+        obj = _cast(object, lambda: generics.Box);
+        (obj).set(_cast((args)[0], lambda: int));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -97,11 +97,11 @@ class generics_Box_quark_int__get_Method(quark.reflect.Method):
         super(generics_Box_quark_int__get_Method, self).__init__(u"quark.int", u"get", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.Box);
         return (obj).get()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -124,7 +124,7 @@ class generics_Box_quark_int_(quark.reflect.Class):
         return generics.Box()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -141,12 +141,12 @@ class generics_Crate_quark_Object__set_Method(quark.reflect.Method):
         super(generics_Crate_quark_Object__set_Method, self).__init__(u"quark.void", u"set", _List([u"quark.Object"]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.Crate);
         (obj).set((args)[0]);
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -162,11 +162,11 @@ class generics_Crate_quark_Object__get_Method(quark.reflect.Method):
         super(generics_Crate_quark_Object__get_Method, self).__init__(u"quark.Object", u"get", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.Crate);
         return (obj).get()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -189,7 +189,7 @@ class generics_Crate_quark_Object_(quark.reflect.Class):
         return generics.Crate()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -213,7 +213,7 @@ class generics_Sack(quark.reflect.Class):
         return generics.Sack()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -230,11 +230,11 @@ class generics_Matrix_quark_Object____get___Method(quark.reflect.Method):
         super(generics_Matrix_quark_Object____get___Method, self).__init__(u"quark.Object", u"__get__", _List([u"quark.int", u"quark.int"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj)._q__get__((args)[0], (args)[1])
+        obj = _cast(object, lambda: generics.Matrix);
+        return (obj)._q__get__(_cast((args)[0], lambda: int), _cast((args)[1], lambda: int))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -250,12 +250,12 @@ class generics_Matrix_quark_Object____set___Method(quark.reflect.Method):
         super(generics_Matrix_quark_Object____set___Method, self).__init__(u"quark.void", u"__set__", _List([u"quark.int", u"quark.int", u"quark.Object"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj)._q__set__((args)[0], (args)[1], (args)[2]);
+        obj = _cast(object, lambda: generics.Matrix);
+        (obj)._q__set__(_cast((args)[0], lambda: int), _cast((args)[1], lambda: int), (args)[2]);
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -275,10 +275,10 @@ class generics_Matrix_quark_Object_(quark.reflect.Class):
         (self).methods = _List([generics_Matrix_quark_Object____get___Method(), generics_Matrix_quark_Object____set___Method()])
 
     def construct(self, args):
-        return generics.Matrix((args)[0], (args)[1])
+        return generics.Matrix(_cast((args)[0], lambda: int), _cast((args)[1], lambda: int))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -295,11 +295,11 @@ class generics_constructors_Box_quark_Object__get_Method(quark.reflect.Method):
         super(generics_constructors_Box_quark_Object__get_Method, self).__init__(u"quark.Object", u"get", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.constructors.Box);
         return (obj).get()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -322,7 +322,7 @@ class generics_constructors_Box_quark_Object_(quark.reflect.Class):
         return generics.constructors.Box((args)[0])
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -339,11 +339,11 @@ class generics_pkg_Foo_quark_Object__foo_Method(quark.reflect.Method):
         super(generics_pkg_Foo_quark_Object__foo_Method, self).__init__(u"quark.Object", u"foo", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.pkg.Foo);
         return (obj).foo()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -359,11 +359,11 @@ class generics_pkg_Foo_quark_Object__get_Method(quark.reflect.Method):
         super(generics_pkg_Foo_quark_Object__get_Method, self).__init__(u"quark.Object", u"get", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.pkg.Foo);
         return (obj).get()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -386,7 +386,7 @@ class generics_pkg_Foo_quark_Object_(quark.reflect.Class):
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -403,11 +403,11 @@ class generics_pkg_StringFoo_get_Method(quark.reflect.Method):
         super(generics_pkg_StringFoo_get_Method, self).__init__(u"quark.String", u"get", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.pkg.StringFoo);
         return (obj).get()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -423,11 +423,11 @@ class generics_pkg_StringFoo_foo_Method(quark.reflect.Method):
         super(generics_pkg_StringFoo_foo_Method, self).__init__(u"quark.String", u"foo", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.pkg.StringFoo);
         return (obj).foo()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -450,7 +450,7 @@ class generics_pkg_StringFoo(quark.reflect.Class):
         return generics.pkg.StringFoo()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -471,10 +471,10 @@ class generics_pkg_Box_quark_String_(quark.reflect.Class):
         (self).methods = _List([])
 
     def construct(self, args):
-        return generics.pkg.Box((args)[0])
+        return generics.pkg.Box(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -495,10 +495,10 @@ class generics_pkg_StringBox(quark.reflect.Class):
         (self).methods = _List([])
 
     def construct(self, args):
-        return generics.pkg.StringBox((args)[0])
+        return generics.pkg.StringBox(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -515,11 +515,11 @@ class generics_ccc_TLSContextInitializer_getValue_Method(quark.reflect.Method):
         super(generics_ccc_TLSContextInitializer_getValue_Method, self).__init__(u"generics.ccc.Context", u"getValue", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.ccc.TLSContextInitializer);
         return (obj).getValue()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -542,7 +542,7 @@ class generics_ccc_TLSContextInitializer(quark.reflect.Class):
         return generics.ccc.TLSContextInitializer()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -559,11 +559,11 @@ class generics_ccc_Context_current_Method(quark.reflect.Method):
         super(generics_ccc_Context_current_Method, self).__init__(u"generics.ccc.Context", u"current", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.ccc.Context);
         return generics.ccc.Context.current()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -579,11 +579,11 @@ class generics_ccc_Context_global_Method(quark.reflect.Method):
         super(generics_ccc_Context_global_Method, self).__init__(u"generics.ccc.Context", u"global", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.ccc.Context);
         return generics.ccc.Context.global_()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -603,10 +603,10 @@ class generics_ccc_Context(quark.reflect.Class):
         (self).methods = _List([generics_ccc_Context_current_Method(), generics_ccc_Context_global_Method()])
 
     def construct(self, args):
-        return generics.ccc.Context((args)[0])
+        return generics.ccc.Context(_cast((args)[0], lambda: generics.ccc.Context))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -623,11 +623,11 @@ class generics_ccc_TLSInitializer_quark_Object__getValue_Method(quark.reflect.Me
         super(generics_ccc_TLSInitializer_quark_Object__getValue_Method, self).__init__(u"quark.Object", u"getValue", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.ccc.TLSInitializer);
         return (obj).getValue()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -650,7 +650,7 @@ class generics_ccc_TLSInitializer_quark_Object_(quark.reflect.Class):
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -667,11 +667,11 @@ class generics_ccc_TLS_generics_ccc_Context__getValue_Method(quark.reflect.Metho
         super(generics_ccc_TLS_generics_ccc_Context__getValue_Method, self).__init__(u"generics.ccc.Context", u"getValue", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: generics.ccc.TLS);
         return (obj).getValue()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -691,10 +691,10 @@ class generics_ccc_TLS_generics_ccc_Context_(quark.reflect.Class):
         (self).methods = _List([generics_ccc_TLS_generics_ccc_Context__getValue_Method()])
 
     def construct(self, args):
-        return generics.ccc.TLS((args)[0])
+        return generics.ccc.TLS(_cast((args)[0], lambda: generics.ccc.TLSInitializer))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -718,7 +718,7 @@ class inheritance_Base(quark.reflect.Class):
         return inheritance.Base()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -742,7 +742,7 @@ class inheritance_Test(quark.reflect.Class):
         return inheritance.Test()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -763,10 +763,10 @@ class inheritance_A(quark.reflect.Class):
         (self).methods = _List([])
 
     def construct(self, args):
-        return inheritance.A((args)[0])
+        return inheritance.A(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -783,12 +783,12 @@ class inheritance_B_greet_Method(quark.reflect.Method):
         super(inheritance_B_greet_Method, self).__init__(u"quark.void", u"greet", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.B);
         (obj).greet();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -808,10 +808,10 @@ class inheritance_B(quark.reflect.Class):
         (self).methods = _List([inheritance_B_greet_Method()])
 
     def construct(self, args):
-        return inheritance.B((args)[0])
+        return inheritance.B(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -828,12 +828,12 @@ class inheritance_C_greet_Method(quark.reflect.Method):
         super(inheritance_C_greet_Method, self).__init__(u"quark.void", u"greet", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.C);
         (obj).greet();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -853,10 +853,10 @@ class inheritance_C(quark.reflect.Class):
         (self).methods = _List([inheritance_C_greet_Method()])
 
     def construct(self, args):
-        return inheritance.C((args)[0])
+        return inheritance.C(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -880,7 +880,7 @@ class inheritance_X(quark.reflect.Class):
         return inheritance.X()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -897,12 +897,12 @@ class inheritance_Y_test_Method(quark.reflect.Method):
         super(inheritance_Y_test_Method, self).__init__(u"quark.void", u"test", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.Y);
         (obj).test();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -922,10 +922,10 @@ class inheritance_Y(quark.reflect.Class):
         (self).methods = _List([inheritance_Y_test_Method()])
 
     def construct(self, args):
-        return inheritance.Y((args)[0])
+        return inheritance.Y(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -942,12 +942,12 @@ class inheritance_t1_A_foo_Method(quark.reflect.Method):
         super(inheritance_t1_A_foo_Method, self).__init__(u"quark.void", u"foo", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.t1.A);
         (obj).foo();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -970,7 +970,7 @@ class inheritance_t1_A(quark.reflect.Class):
         return inheritance.t1.A()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -987,12 +987,12 @@ class inheritance_t1_B_foo_Method(quark.reflect.Method):
         super(inheritance_t1_B_foo_Method, self).__init__(u"quark.void", u"foo", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.t1.B);
         (obj).foo();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1015,7 +1015,7 @@ class inheritance_t1_B(quark.reflect.Class):
         return inheritance.t1.B()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1032,12 +1032,12 @@ class inheritance_t1_C_foo_Method(quark.reflect.Method):
         super(inheritance_t1_C_foo_Method, self).__init__(u"quark.void", u"foo", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.t1.C);
         (obj).foo();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1060,7 +1060,7 @@ class inheritance_t1_C(quark.reflect.Class):
         return inheritance.t1.C()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1084,7 +1084,7 @@ class inheritance_t2_A(quark.reflect.Class):
         return inheritance.t2.A()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1108,7 +1108,7 @@ class inheritance_t2_B(quark.reflect.Class):
         return inheritance.t2.B()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1132,7 +1132,7 @@ class inheritance_t2_X_quark_int_(quark.reflect.Class):
         return inheritance.t2.X()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1156,7 +1156,7 @@ class inheritance_t2_Y(quark.reflect.Class):
         return inheritance.t2.Y()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1173,12 +1173,12 @@ class inheritance_pets_Cat_greet_Method(quark.reflect.Method):
         super(inheritance_pets_Cat_greet_Method, self).__init__(u"quark.void", u"greet", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.pets.Cat);
         (obj).greet();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1201,7 +1201,7 @@ class inheritance_pets_Cat(quark.reflect.Class):
         return inheritance.pets.Cat()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1218,12 +1218,12 @@ class inheritance_pets_Dog_greet_Method(quark.reflect.Method):
         super(inheritance_pets_Dog_greet_Method, self).__init__(u"quark.void", u"greet", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.pets.Dog);
         (obj).greet();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1246,7 +1246,7 @@ class inheritance_pets_Dog(quark.reflect.Class):
         return inheritance.pets.Dog()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1263,11 +1263,11 @@ class inheritance_Message_encode_Method(quark.reflect.Method):
         super(inheritance_Message_encode_Method, self).__init__(u"quark.String", u"encode", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.Message);
         return (obj).encode()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1290,7 +1290,7 @@ class inheritance_Message(quark.reflect.Class):
         return inheritance.Message()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1307,11 +1307,11 @@ class inheritance_Ping_encode_Method(quark.reflect.Method):
         super(inheritance_Ping_encode_Method, self).__init__(u"quark.String", u"encode", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.Ping);
         return (obj).encode()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1334,7 +1334,7 @@ class inheritance_Ping(quark.reflect.Class):
         return inheritance.Ping()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1351,11 +1351,11 @@ class inheritance_Pong_toString_Method(quark.reflect.Method):
         super(inheritance_Pong_toString_Method, self).__init__(u"quark.String", u"toString", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.Pong);
         return (obj).toString()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1371,11 +1371,11 @@ class inheritance_Pong_encode_Method(quark.reflect.Method):
         super(inheritance_Pong_encode_Method, self).__init__(u"quark.String", u"encode", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.Pong);
         return (obj).encode()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1398,7 +1398,7 @@ class inheritance_Pong(quark.reflect.Class):
         return inheritance.Pong()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1415,12 +1415,12 @@ class inheritance_super__A_greet_Method(quark.reflect.Method):
         super(inheritance_super__A_greet_Method, self).__init__(u"quark.void", u"greet", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.super_.A);
         (obj).greet();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1440,10 +1440,10 @@ class inheritance_super__A(quark.reflect.Class):
         (self).methods = _List([inheritance_super__A_greet_Method()])
 
     def construct(self, args):
-        return inheritance.super_.A((args)[0])
+        return inheritance.super_.A(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1460,12 +1460,12 @@ class inheritance_super__B_greet_Method(quark.reflect.Method):
         super(inheritance_super__B_greet_Method, self).__init__(u"quark.void", u"greet", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.super_.B);
         (obj).greet();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1488,7 +1488,7 @@ class inheritance_super__B(quark.reflect.Class):
         return inheritance.super_.B()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1505,12 +1505,12 @@ class inheritance_use_before_def_Bar_go_Method(quark.reflect.Method):
         super(inheritance_use_before_def_Bar_go_Method, self).__init__(u"quark.void", u"go", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: inheritance.use_before_def.Bar);
         (obj).go();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1533,7 +1533,7 @@ class inheritance_use_before_def_Bar(quark.reflect.Class):
         return inheritance.use_before_def.Bar()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1557,7 +1557,7 @@ class inheritance_use_before_def_Foo(quark.reflect.Class):
         return inheritance.use_before_def.Foo()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1574,12 +1574,12 @@ class interfaces_A_foo_Method(quark.reflect.Method):
         super(interfaces_A_foo_Method, self).__init__(u"quark.void", u"foo", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.A);
         (obj).foo();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1595,12 +1595,12 @@ class interfaces_A_bar_Method(quark.reflect.Method):
         super(interfaces_A_bar_Method, self).__init__(u"quark.void", u"bar", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.A);
         (obj).bar();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1623,7 +1623,7 @@ class interfaces_A(quark.reflect.Class):
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1640,12 +1640,12 @@ class interfaces_B_bar_Method(quark.reflect.Method):
         super(interfaces_B_bar_Method, self).__init__(u"quark.void", u"bar", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.B);
         (obj).bar();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1668,7 +1668,7 @@ class interfaces_B(quark.reflect.Class):
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1685,12 +1685,12 @@ class interfaces_C_foo_Method(quark.reflect.Method):
         super(interfaces_C_foo_Method, self).__init__(u"quark.void", u"foo", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.C);
         (obj).foo();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1713,7 +1713,7 @@ class interfaces_C(quark.reflect.Class):
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1730,12 +1730,12 @@ class interfaces_T1_foo_Method(quark.reflect.Method):
         super(interfaces_T1_foo_Method, self).__init__(u"quark.void", u"foo", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.T1);
         (obj).foo();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1751,12 +1751,12 @@ class interfaces_T1_bar_Method(quark.reflect.Method):
         super(interfaces_T1_bar_Method, self).__init__(u"quark.void", u"bar", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.T1);
         (obj).bar();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1779,7 +1779,7 @@ class interfaces_T1(quark.reflect.Class):
         return interfaces.T1()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1796,12 +1796,12 @@ class interfaces_T2_foo_Method(quark.reflect.Method):
         super(interfaces_T2_foo_Method, self).__init__(u"quark.void", u"foo", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.T2);
         (obj).foo();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1817,12 +1817,12 @@ class interfaces_T2_bar_Method(quark.reflect.Method):
         super(interfaces_T2_bar_Method, self).__init__(u"quark.void", u"bar", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.T2);
         (obj).bar();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1845,7 +1845,7 @@ class interfaces_T2(quark.reflect.Class):
         return interfaces.T2()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1862,12 +1862,12 @@ class interfaces_T3_foo_Method(quark.reflect.Method):
         super(interfaces_T3_foo_Method, self).__init__(u"quark.void", u"foo", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.T3);
         (obj).foo();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1883,12 +1883,12 @@ class interfaces_T3_bar_Method(quark.reflect.Method):
         super(interfaces_T3_bar_Method, self).__init__(u"quark.void", u"bar", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.T3);
         (obj).bar();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1911,7 +1911,7 @@ class interfaces_T3(quark.reflect.Class):
         return interfaces.T3()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1928,12 +1928,12 @@ class interfaces_T4_foo_Method(quark.reflect.Method):
         super(interfaces_T4_foo_Method, self).__init__(u"quark.void", u"foo", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.T4);
         (obj).foo();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1949,12 +1949,12 @@ class interfaces_T4_bar_Method(quark.reflect.Method):
         super(interfaces_T4_bar_Method, self).__init__(u"quark.void", u"bar", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.T4);
         (obj).bar();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1977,7 +1977,7 @@ class interfaces_T4(quark.reflect.Class):
         return interfaces.T4()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -1994,12 +1994,12 @@ class interfaces_T5_foo_Method(quark.reflect.Method):
         super(interfaces_T5_foo_Method, self).__init__(u"quark.void", u"foo", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.T5);
         (obj).foo();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2015,12 +2015,12 @@ class interfaces_T5_bar_Method(quark.reflect.Method):
         super(interfaces_T5_bar_Method, self).__init__(u"quark.void", u"bar", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.T5);
         (obj).bar();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2043,7 +2043,7 @@ class interfaces_T5(quark.reflect.Class):
         return interfaces.T5()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2060,12 +2060,12 @@ class interfaces_Foo_m1_Method(quark.reflect.Method):
         super(interfaces_Foo_m1_Method, self).__init__(u"quark.void", u"m1", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.Foo);
         (obj).m1();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2081,12 +2081,12 @@ class interfaces_Foo_m2_Method(quark.reflect.Method):
         super(interfaces_Foo_m2_Method, self).__init__(u"quark.void", u"m2", _List([u"quark.int"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).m2((args)[0]);
+        obj = _cast(object, lambda: interfaces.Foo);
+        (obj).m2(_cast((args)[0], lambda: int));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2102,12 +2102,12 @@ class interfaces_Foo_m3_Method(quark.reflect.Method):
         super(interfaces_Foo_m3_Method, self).__init__(u"quark.void", u"m3", _List([u"quark.List<quark.String>"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).m3((args)[0]);
+        obj = _cast(object, lambda: interfaces.Foo);
+        (obj).m3(_cast((args)[0], lambda: _List));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2130,7 +2130,7 @@ class interfaces_Foo(quark.reflect.Class):
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2147,12 +2147,12 @@ class interfaces_Bar_quark_Object__m1_Method(quark.reflect.Method):
         super(interfaces_Bar_quark_Object__m1_Method, self).__init__(u"quark.void", u"m1", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.Bar);
         (obj).m1();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2168,12 +2168,12 @@ class interfaces_Bar_quark_Object__m2_Method(quark.reflect.Method):
         super(interfaces_Bar_quark_Object__m2_Method, self).__init__(u"quark.void", u"m2", _List([u"quark.Object"]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.Bar);
         (obj).m2((args)[0]);
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2189,12 +2189,12 @@ class interfaces_Bar_quark_Object__m3_Method(quark.reflect.Method):
         super(interfaces_Bar_quark_Object__m3_Method, self).__init__(u"quark.void", u"m3", _List([u"quark.List<quark.Object>"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).m3((args)[0]);
+        obj = _cast(object, lambda: interfaces.Bar);
+        (obj).m3(_cast((args)[0], lambda: _List));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2217,7 +2217,7 @@ class interfaces_Bar_quark_Object_(quark.reflect.Class):
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2234,12 +2234,12 @@ class interfaces_Baz_m2_Method(quark.reflect.Method):
         super(interfaces_Baz_m2_Method, self).__init__(u"quark.void", u"m2", _List([u"quark.int"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).m2((args)[0]);
+        obj = _cast(object, lambda: interfaces.Baz);
+        (obj).m2(_cast((args)[0], lambda: int));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2255,12 +2255,12 @@ class interfaces_Baz_m1_Method(quark.reflect.Method):
         super(interfaces_Baz_m1_Method, self).__init__(u"quark.void", u"m1", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.Baz);
         (obj).m1();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2276,12 +2276,12 @@ class interfaces_Baz_m3_Method(quark.reflect.Method):
         super(interfaces_Baz_m3_Method, self).__init__(u"quark.void", u"m3", _List([u"quark.List<quark.String>"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).m3((args)[0]);
+        obj = _cast(object, lambda: interfaces.Baz);
+        (obj).m3(_cast((args)[0], lambda: _List));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2304,7 +2304,7 @@ class interfaces_Baz(quark.reflect.Class):
         return interfaces.Baz()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2321,12 +2321,12 @@ class interfaces_RazBar_m1_Method(quark.reflect.Method):
         super(interfaces_RazBar_m1_Method, self).__init__(u"quark.void", u"m1", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.RazBar);
         (obj).m1();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2342,12 +2342,12 @@ class interfaces_RazBar_m2_Method(quark.reflect.Method):
         super(interfaces_RazBar_m2_Method, self).__init__(u"quark.void", u"m2", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).m2((args)[0]);
+        obj = _cast(object, lambda: interfaces.RazBar);
+        (obj).m2(_cast((args)[0], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2363,12 +2363,12 @@ class interfaces_RazBar_m3_Method(quark.reflect.Method):
         super(interfaces_RazBar_m3_Method, self).__init__(u"quark.void", u"m3", _List([u"quark.List<quark.Object>"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).m3((args)[0]);
+        obj = _cast(object, lambda: interfaces.RazBar);
+        (obj).m3(_cast((args)[0], lambda: _List));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2391,7 +2391,7 @@ class interfaces_RazBar(quark.reflect.Class):
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2408,12 +2408,12 @@ class interfaces_RazFaz_quark_Object__m1_Method(quark.reflect.Method):
         super(interfaces_RazFaz_quark_Object__m1_Method, self).__init__(u"quark.void", u"m1", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.RazFaz);
         (obj).m1();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2429,12 +2429,12 @@ class interfaces_RazFaz_quark_Object__m2_Method(quark.reflect.Method):
         super(interfaces_RazFaz_quark_Object__m2_Method, self).__init__(u"quark.void", u"m2", _List([u"quark.Object"]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.RazFaz);
         (obj).m2((args)[0]);
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2450,12 +2450,12 @@ class interfaces_RazFaz_quark_Object__m3_Method(quark.reflect.Method):
         super(interfaces_RazFaz_quark_Object__m3_Method, self).__init__(u"quark.void", u"m3", _List([u"quark.List<quark.Object>"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).m3((args)[0]);
+        obj = _cast(object, lambda: interfaces.RazFaz);
+        (obj).m3(_cast((args)[0], lambda: _List));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2478,7 +2478,7 @@ class interfaces_RazFaz_quark_Object_(quark.reflect.Class):
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2495,12 +2495,12 @@ class interfaces_BazBar_m1_Method(quark.reflect.Method):
         super(interfaces_BazBar_m1_Method, self).__init__(u"quark.void", u"m1", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.BazBar);
         (obj).m1();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2516,12 +2516,12 @@ class interfaces_BazBar_m2_Method(quark.reflect.Method):
         super(interfaces_BazBar_m2_Method, self).__init__(u"quark.void", u"m2", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).m2((args)[0]);
+        obj = _cast(object, lambda: interfaces.BazBar);
+        (obj).m2(_cast((args)[0], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2537,12 +2537,12 @@ class interfaces_BazBar_m3_Method(quark.reflect.Method):
         super(interfaces_BazBar_m3_Method, self).__init__(u"quark.void", u"m3", _List([u"quark.List<quark.String>"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).m3((args)[0]);
+        obj = _cast(object, lambda: interfaces.BazBar);
+        (obj).m3(_cast((args)[0], lambda: _List));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2565,7 +2565,7 @@ class interfaces_BazBar(quark.reflect.Class):
         return interfaces.BazBar()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2582,12 +2582,12 @@ class interfaces_BazFaz_quark_Object__m1_Method(quark.reflect.Method):
         super(interfaces_BazFaz_quark_Object__m1_Method, self).__init__(u"quark.void", u"m1", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.BazFaz);
         (obj).m1();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2603,12 +2603,12 @@ class interfaces_BazFaz_quark_Object__m2_Method(quark.reflect.Method):
         super(interfaces_BazFaz_quark_Object__m2_Method, self).__init__(u"quark.void", u"m2", _List([u"quark.Object"]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: interfaces.BazFaz);
         (obj).m2((args)[0]);
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2624,12 +2624,12 @@ class interfaces_BazFaz_quark_Object__m3_Method(quark.reflect.Method):
         super(interfaces_BazFaz_quark_Object__m3_Method, self).__init__(u"quark.void", u"m3", _List([u"quark.List<quark.Object>"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).m3((args)[0]);
+        obj = _cast(object, lambda: interfaces.BazFaz);
+        (obj).m3(_cast((args)[0], lambda: _List));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2652,7 +2652,7 @@ class interfaces_BazFaz_quark_Object_(quark.reflect.Class):
         return interfaces.BazFaz()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2669,11 +2669,11 @@ class classes_Overload___add___Method(quark.reflect.Method):
         super(classes_Overload___add___Method, self).__init__(u"classes.Overload", u"__add__", _List([u"classes.Overload"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).__add__((args)[0])
+        obj = _cast(object, lambda: classes.Overload);
+        return (obj).__add__(_cast((args)[0], lambda: classes.Overload))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2689,11 +2689,11 @@ class classes_Overload___mul___Method(quark.reflect.Method):
         super(classes_Overload___mul___Method, self).__init__(u"classes.Overload", u"__mul__", _List([u"classes.Overload"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).__mul__((args)[0])
+        obj = _cast(object, lambda: classes.Overload);
+        return (obj).__mul__(_cast((args)[0], lambda: classes.Overload))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2709,12 +2709,12 @@ class classes_Overload_test_Method(quark.reflect.Method):
         super(classes_Overload_test_Method, self).__init__(u"quark.void", u"test", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: classes.Overload);
         (obj).test();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2734,10 +2734,10 @@ class classes_Overload(quark.reflect.Class):
         (self).methods = _List([classes_Overload___add___Method(), classes_Overload___mul___Method(), classes_Overload_test_Method()])
 
     def construct(self, args):
-        return classes.Overload((args)[0])
+        return classes.Overload(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2754,12 +2754,12 @@ class classes_Test_test_Method(quark.reflect.Method):
         super(classes_Test_test_Method, self).__init__(u"quark.void", u"test", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: classes.Test);
         (obj).test();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2782,7 +2782,7 @@ class classes_Test(quark.reflect.Class):
         return classes.Test()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2799,12 +2799,12 @@ class classes_string_test_check_Method(quark.reflect.Method):
         super(classes_string_test_check_Method, self).__init__(u"quark.void", u"check", _List([u"quark.String", u"quark.String", u"quark.String", u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+        obj = _cast(object, lambda: classes.string_test);
+        (obj).check(_cast((args)[0], lambda: unicode), _cast((args)[1], lambda: unicode), _cast((args)[2], lambda: unicode), _cast((args)[3], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2827,7 +2827,7 @@ class classes_string_test(quark.reflect.Class):
         return classes.string_test()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2844,11 +2844,11 @@ class classes_test_size_does_Method(quark.reflect.Method):
         super(classes_test_size_does_Method, self).__init__(u"classes.test_size", u"does", _List([u"quark.int"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).does((args)[0])
+        obj = _cast(object, lambda: classes.test_size);
+        return (obj).does(_cast((args)[0], lambda: int))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2864,12 +2864,12 @@ class classes_test_size_check_Method(quark.reflect.Method):
         super(classes_test_size_check_Method, self).__init__(u"quark.void", u"check", _List([u"quark.String", u"quark.String", u"quark.String", u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+        obj = _cast(object, lambda: classes.test_size);
+        (obj).check(_cast((args)[0], lambda: unicode), _cast((args)[1], lambda: unicode), _cast((args)[2], lambda: unicode), _cast((args)[3], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2889,10 +2889,10 @@ class classes_test_size(quark.reflect.Class):
         (self).methods = _List([classes_test_size_does_Method(), classes_test_size_check_Method()])
 
     def construct(self, args):
-        return classes.test_size((args)[0])
+        return classes.test_size(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2909,11 +2909,11 @@ class classes_test_startsWith_that_Method(quark.reflect.Method):
         super(classes_test_startsWith_that_Method, self).__init__(u"classes.test_startsWith", u"that", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).that((args)[0])
+        obj = _cast(object, lambda: classes.test_startsWith);
+        return (obj).that(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2929,11 +2929,11 @@ class classes_test_startsWith_does_Method(quark.reflect.Method):
         super(classes_test_startsWith_does_Method, self).__init__(u"classes.test_startsWith", u"does", _List([u"quark.bool"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).does((args)[0])
+        obj = _cast(object, lambda: classes.test_startsWith);
+        return (obj).does(_cast((args)[0], lambda: bool))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2949,12 +2949,12 @@ class classes_test_startsWith_check_Method(quark.reflect.Method):
         super(classes_test_startsWith_check_Method, self).__init__(u"quark.void", u"check", _List([u"quark.String", u"quark.String", u"quark.String", u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+        obj = _cast(object, lambda: classes.test_startsWith);
+        (obj).check(_cast((args)[0], lambda: unicode), _cast((args)[1], lambda: unicode), _cast((args)[2], lambda: unicode), _cast((args)[3], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2974,10 +2974,10 @@ class classes_test_startsWith(quark.reflect.Class):
         (self).methods = _List([classes_test_startsWith_that_Method(), classes_test_startsWith_does_Method(), classes_test_startsWith_check_Method()])
 
     def construct(self, args):
-        return classes.test_startsWith((args)[0])
+        return classes.test_startsWith(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -2994,11 +2994,11 @@ class classes_test_endsWith_that_Method(quark.reflect.Method):
         super(classes_test_endsWith_that_Method, self).__init__(u"classes.test_endsWith", u"that", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).that((args)[0])
+        obj = _cast(object, lambda: classes.test_endsWith);
+        return (obj).that(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3014,11 +3014,11 @@ class classes_test_endsWith_does_Method(quark.reflect.Method):
         super(classes_test_endsWith_does_Method, self).__init__(u"classes.test_endsWith", u"does", _List([u"quark.bool"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).does((args)[0])
+        obj = _cast(object, lambda: classes.test_endsWith);
+        return (obj).does(_cast((args)[0], lambda: bool))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3034,12 +3034,12 @@ class classes_test_endsWith_check_Method(quark.reflect.Method):
         super(classes_test_endsWith_check_Method, self).__init__(u"quark.void", u"check", _List([u"quark.String", u"quark.String", u"quark.String", u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+        obj = _cast(object, lambda: classes.test_endsWith);
+        (obj).check(_cast((args)[0], lambda: unicode), _cast((args)[1], lambda: unicode), _cast((args)[2], lambda: unicode), _cast((args)[3], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3059,10 +3059,10 @@ class classes_test_endsWith(quark.reflect.Class):
         (self).methods = _List([classes_test_endsWith_that_Method(), classes_test_endsWith_does_Method(), classes_test_endsWith_check_Method()])
 
     def construct(self, args):
-        return classes.test_endsWith((args)[0])
+        return classes.test_endsWith(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3079,11 +3079,11 @@ class classes_test_find_that_Method(quark.reflect.Method):
         super(classes_test_find_that_Method, self).__init__(u"classes.test_find", u"that", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).that((args)[0])
+        obj = _cast(object, lambda: classes.test_find);
+        return (obj).that(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3099,11 +3099,11 @@ class classes_test_find_does_Method(quark.reflect.Method):
         super(classes_test_find_does_Method, self).__init__(u"classes.test_find", u"does", _List([u"quark.int"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).does((args)[0])
+        obj = _cast(object, lambda: classes.test_find);
+        return (obj).does(_cast((args)[0], lambda: int))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3119,12 +3119,12 @@ class classes_test_find_check_Method(quark.reflect.Method):
         super(classes_test_find_check_Method, self).__init__(u"quark.void", u"check", _List([u"quark.String", u"quark.String", u"quark.String", u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+        obj = _cast(object, lambda: classes.test_find);
+        (obj).check(_cast((args)[0], lambda: unicode), _cast((args)[1], lambda: unicode), _cast((args)[2], lambda: unicode), _cast((args)[3], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3144,10 +3144,10 @@ class classes_test_find(quark.reflect.Class):
         (self).methods = _List([classes_test_find_that_Method(), classes_test_find_does_Method(), classes_test_find_check_Method()])
 
     def construct(self, args):
-        return classes.test_find((args)[0])
+        return classes.test_find(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3164,11 +3164,11 @@ class classes_test_substring_that_Method(quark.reflect.Method):
         super(classes_test_substring_that_Method, self).__init__(u"classes.test_substring", u"that", _List([u"quark.int", u"quark.int"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).that((args)[0], (args)[1])
+        obj = _cast(object, lambda: classes.test_substring);
+        return (obj).that(_cast((args)[0], lambda: int), _cast((args)[1], lambda: int))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3184,11 +3184,11 @@ class classes_test_substring_does_Method(quark.reflect.Method):
         super(classes_test_substring_does_Method, self).__init__(u"classes.test_substring", u"does", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).does((args)[0])
+        obj = _cast(object, lambda: classes.test_substring);
+        return (obj).does(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3204,12 +3204,12 @@ class classes_test_substring_check_Method(quark.reflect.Method):
         super(classes_test_substring_check_Method, self).__init__(u"quark.void", u"check", _List([u"quark.String", u"quark.String", u"quark.String", u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+        obj = _cast(object, lambda: classes.test_substring);
+        (obj).check(_cast((args)[0], lambda: unicode), _cast((args)[1], lambda: unicode), _cast((args)[2], lambda: unicode), _cast((args)[3], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3229,10 +3229,10 @@ class classes_test_substring(quark.reflect.Class):
         (self).methods = _List([classes_test_substring_that_Method(), classes_test_substring_does_Method(), classes_test_substring_check_Method()])
 
     def construct(self, args):
-        return classes.test_substring((args)[0])
+        return classes.test_substring(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3249,11 +3249,11 @@ class classes_test_replace_that_Method(quark.reflect.Method):
         super(classes_test_replace_that_Method, self).__init__(u"classes.test_replace", u"that", _List([u"quark.String", u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).that((args)[0], (args)[1])
+        obj = _cast(object, lambda: classes.test_replace);
+        return (obj).that(_cast((args)[0], lambda: unicode), _cast((args)[1], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3269,11 +3269,11 @@ class classes_test_replace_does_Method(quark.reflect.Method):
         super(classes_test_replace_does_Method, self).__init__(u"classes.test_replace", u"does", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).does((args)[0])
+        obj = _cast(object, lambda: classes.test_replace);
+        return (obj).does(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3289,12 +3289,12 @@ class classes_test_replace_check_Method(quark.reflect.Method):
         super(classes_test_replace_check_Method, self).__init__(u"quark.void", u"check", _List([u"quark.String", u"quark.String", u"quark.String", u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+        obj = _cast(object, lambda: classes.test_replace);
+        (obj).check(_cast((args)[0], lambda: unicode), _cast((args)[1], lambda: unicode), _cast((args)[2], lambda: unicode), _cast((args)[3], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3314,10 +3314,10 @@ class classes_test_replace(quark.reflect.Class):
         (self).methods = _List([classes_test_replace_that_Method(), classes_test_replace_does_Method(), classes_test_replace_check_Method()])
 
     def construct(self, args):
-        return classes.test_replace((args)[0])
+        return classes.test_replace(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3334,11 +3334,11 @@ class classes_test_join_that_Method(quark.reflect.Method):
         super(classes_test_join_that_Method, self).__init__(u"classes.test_join", u"that", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: classes.test_join);
         return (obj).that()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3354,11 +3354,11 @@ class classes_test_join_a_Method(quark.reflect.Method):
         super(classes_test_join_a_Method, self).__init__(u"classes.test_join", u"a", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).a((args)[0])
+        obj = _cast(object, lambda: classes.test_join);
+        return (obj).a(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3374,11 +3374,11 @@ class classes_test_join_does_Method(quark.reflect.Method):
         super(classes_test_join_does_Method, self).__init__(u"classes.test_join", u"does", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).does((args)[0])
+        obj = _cast(object, lambda: classes.test_join);
+        return (obj).does(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3394,12 +3394,12 @@ class classes_test_join_check_Method(quark.reflect.Method):
         super(classes_test_join_check_Method, self).__init__(u"quark.void", u"check", _List([u"quark.String", u"quark.String", u"quark.String", u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+        obj = _cast(object, lambda: classes.test_join);
+        (obj).check(_cast((args)[0], lambda: unicode), _cast((args)[1], lambda: unicode), _cast((args)[2], lambda: unicode), _cast((args)[3], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3419,10 +3419,10 @@ class classes_test_join(quark.reflect.Class):
         (self).methods = _List([classes_test_join_that_Method(), classes_test_join_a_Method(), classes_test_join_does_Method(), classes_test_join_check_Method()])
 
     def construct(self, args):
-        return classes.test_join((args)[0])
+        return classes.test_join(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3439,11 +3439,11 @@ class classes_test_split_that_Method(quark.reflect.Method):
         super(classes_test_split_that_Method, self).__init__(u"classes.test_split", u"that", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).that((args)[0])
+        obj = _cast(object, lambda: classes.test_split);
+        return (obj).that(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3459,11 +3459,11 @@ class classes_test_split_does_Method(quark.reflect.Method):
         super(classes_test_split_does_Method, self).__init__(u"classes.test_split", u"does", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).does((args)[0])
+        obj = _cast(object, lambda: classes.test_split);
+        return (obj).does(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3479,12 +3479,12 @@ class classes_test_split_check_Method(quark.reflect.Method):
         super(classes_test_split_check_Method, self).__init__(u"quark.void", u"check", _List([u"quark.String", u"quark.String", u"quark.String", u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).check((args)[0], (args)[1], (args)[2], (args)[3]);
+        obj = _cast(object, lambda: classes.test_split);
+        (obj).check(_cast((args)[0], lambda: unicode), _cast((args)[1], lambda: unicode), _cast((args)[2], lambda: unicode), _cast((args)[3], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3504,10 +3504,10 @@ class classes_test_split(quark.reflect.Class):
         (self).methods = _List([classes_test_split_that_Method(), classes_test_split_does_Method(), classes_test_split_check_Method()])
 
     def construct(self, args):
-        return classes.test_split((args)[0], (args)[1])
+        return classes.test_split(_cast((args)[0], lambda: unicode), _cast((args)[1], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3524,11 +3524,11 @@ class classes_stuff_Test_foo_Method(quark.reflect.Method):
         super(classes_stuff_Test_foo_Method, self).__init__(u"classes.stuff.Test", u"foo", _List([u"classes.stuff.Test"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).foo((args)[0])
+        obj = _cast(object, lambda: classes.stuff.Test);
+        return (obj).foo(_cast((args)[0], lambda: classes.stuff.Test))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3544,12 +3544,12 @@ class classes_stuff_Test_test_Method(quark.reflect.Method):
         super(classes_stuff_Test_test_Method, self).__init__(u"quark.void", u"test", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: classes.stuff.Test);
         (obj).test();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3572,7 +3572,7 @@ class classes_stuff_Test(quark.reflect.Class):
         return classes.stuff.Test()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3589,12 +3589,12 @@ class statics_Foo_setCount_Method(quark.reflect.Method):
         super(statics_Foo_setCount_Method, self).__init__(u"quark.void", u"setCount", _List([u"quark.int"]));
 
     def invoke(self, object, args):
-        obj = object;
-        statics.Foo.setCount((args)[0]);
+        obj = _cast(object, lambda: statics.Foo);
+        statics.Foo.setCount(_cast((args)[0], lambda: int));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3610,11 +3610,11 @@ class statics_Foo_getCount_Method(quark.reflect.Method):
         super(statics_Foo_getCount_Method, self).__init__(u"quark.int", u"getCount", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: statics.Foo);
         return statics.Foo.getCount()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3630,12 +3630,12 @@ class statics_Foo_test1_Method(quark.reflect.Method):
         super(statics_Foo_test1_Method, self).__init__(u"quark.void", u"test1", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: statics.Foo);
         (obj).test1();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3651,12 +3651,12 @@ class statics_Foo_test2_Method(quark.reflect.Method):
         super(statics_Foo_test2_Method, self).__init__(u"quark.void", u"test2", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: statics.Foo);
         (obj).test2();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3672,12 +3672,12 @@ class statics_Foo_test3_Method(quark.reflect.Method):
         super(statics_Foo_test3_Method, self).__init__(u"quark.void", u"test3", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: statics.Foo);
         (obj).test3();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3693,12 +3693,12 @@ class statics_Foo_test4_Method(quark.reflect.Method):
         super(statics_Foo_test4_Method, self).__init__(u"quark.void", u"test4", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: statics.Foo);
         (obj).test4();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3721,7 +3721,7 @@ class statics_Foo(quark.reflect.Class):
         return statics.Foo()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3738,11 +3738,11 @@ class docs_Test_test_Method(quark.reflect.Method):
         super(docs_Test_test_Method, self).__init__(u"quark.int", u"test", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).test((args)[0])
+        obj = _cast(object, lambda: docs.Test);
+        return (obj).test(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3765,7 +3765,7 @@ class docs_Test(quark.reflect.Class):
         return docs.Test()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3789,7 +3789,7 @@ class quark_List_quark_List_quark_Object__(quark.reflect.Class):
         return _List()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3813,7 +3813,7 @@ class quark_List_quark_Object_(quark.reflect.Class):
         return _List()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3837,7 +3837,7 @@ class quark_List_quark_String_(quark.reflect.Class):
         return _List()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -3852,7 +3852,7 @@ class Root(object):
     def __init__(self): self._init()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None

--- a/quarkc/test/ffi/expected/py/signatures/statics/__init__.py
+++ b/quarkc/test/ffi/expected/py/signatures/statics/__init__.py
@@ -41,7 +41,7 @@ class Foo(object):
 
     def _setField(self, name, value):
         if ((name) == (u"count")):
-            Foo.count = value
+            Foo.count = _cast(value, lambda: int)
 
 
 Foo.count = None

--- a/quarkc/test/ffi/expected/py/slackpack/slack/__init__.py
+++ b/quarkc/test/ffi/expected/py/slackpack/slack/__init__.py
@@ -50,10 +50,10 @@ class User(object):
 
     def _setField(self, name, value):
         if ((name) == (u"client")):
-            (self).client = value
+            (self).client = _cast(value, lambda: Client)
 
         if ((name) == (u"user")):
-            (self).user = value
+            (self).user = _cast(value, lambda: unicode)
 
 
 User.slack_User_ref = slackpack_md.Root.slack_User_md
@@ -88,10 +88,10 @@ class Channel(object):
 
     def _setField(self, name, value):
         if ((name) == (u"client")):
-            (self).client = value
+            (self).client = _cast(value, lambda: Client)
 
         if ((name) == (u"channel")):
-            (self).channel = value
+            (self).channel = _cast(value, lambda: unicode)
 
 
 Channel.slack_Channel_ref = slackpack_md.Root.slack_Channel_md
@@ -134,7 +134,7 @@ class Client(object):
         pass
 
     def construct(self, type):
-        return None
+        return _cast(None, lambda: event.SlackEvent)
 
     def onWSMessage(self, socket, message):
         pass
@@ -165,19 +165,19 @@ class Client(object):
 
     def _setField(self, name, value):
         if ((name) == (u"runtime")):
-            (self).runtime = value
+            (self).runtime = _cast(value, lambda: quark.Runtime)
 
         if ((name) == (u"token")):
-            (self).token = value
+            (self).token = _cast(value, lambda: unicode)
 
         if ((name) == (u"handler")):
-            (self).handler = value
+            (self).handler = _cast(value, lambda: SlackHandler)
 
         if ((name) == (u"event_id")):
-            (self).event_id = value
+            (self).event_id = _cast(value, lambda: int)
 
         if ((name) == (u"socket")):
-            (self).socket = value
+            (self).socket = _cast(value, lambda: quark.WebSocket)
 
     def onWSInit(self, socket):
         pass

--- a/quarkc/test/ffi/expected/py/slackpack/slack/event/__init__.py
+++ b/quarkc/test/ffi/expected/py/slackpack/slack/event/__init__.py
@@ -43,16 +43,16 @@ class SlackEvent(object):
 
     def _setField(self, name, value):
         if ((name) == (u"type")):
-            (self).type = value
+            (self).type = _cast(value, lambda: unicode)
 
         if ((name) == (u"user")):
-            (self).user = value
+            (self).user = _cast(value, lambda: slack.User)
 
         if ((name) == (u"channel")):
-            (self).channel = value
+            (self).channel = _cast(value, lambda: slack.Channel)
 
         if ((name) == (u"timestamp")):
-            (self).timestamp = value
+            (self).timestamp = _cast(value, lambda: unicode)
 
 
 SlackEvent.slack_event_SlackEvent_ref = slackpack_md.Root.slack_event_SlackEvent_md
@@ -100,22 +100,22 @@ class SlackError(SlackEvent):
 
     def _setField(self, name, value):
         if ((name) == (u"type")):
-            (self).type = value
+            (self).type = _cast(value, lambda: unicode)
 
         if ((name) == (u"user")):
-            (self).user = value
+            (self).user = _cast(value, lambda: slack.User)
 
         if ((name) == (u"channel")):
-            (self).channel = value
+            (self).channel = _cast(value, lambda: slack.Channel)
 
         if ((name) == (u"timestamp")):
-            (self).timestamp = value
+            (self).timestamp = _cast(value, lambda: unicode)
 
         if ((name) == (u"code")):
-            (self).code = value
+            (self).code = _cast(value, lambda: int)
 
         if ((name) == (u"text")):
-            (self).text = value
+            (self).text = _cast(value, lambda: unicode)
 
 
 SlackError.slack_event_SlackError_ref = slackpack_md.Root.slack_event_SlackError_md
@@ -152,16 +152,16 @@ class Hello(SlackEvent):
 
     def _setField(self, name, value):
         if ((name) == (u"type")):
-            (self).type = value
+            (self).type = _cast(value, lambda: unicode)
 
         if ((name) == (u"user")):
-            (self).user = value
+            (self).user = _cast(value, lambda: slack.User)
 
         if ((name) == (u"channel")):
-            (self).channel = value
+            (self).channel = _cast(value, lambda: slack.Channel)
 
         if ((name) == (u"timestamp")):
-            (self).timestamp = value
+            (self).timestamp = _cast(value, lambda: unicode)
 
 
 Hello.slack_event_Hello_ref = slackpack_md.Root.slack_event_Hello_md
@@ -217,28 +217,28 @@ class Message(SlackEvent):
 
     def _setField(self, name, value):
         if ((name) == (u"type")):
-            (self).type = value
+            (self).type = _cast(value, lambda: unicode)
 
         if ((name) == (u"user")):
-            (self).user = value
+            (self).user = _cast(value, lambda: slack.User)
 
         if ((name) == (u"channel")):
-            (self).channel = value
+            (self).channel = _cast(value, lambda: slack.Channel)
 
         if ((name) == (u"timestamp")):
-            (self).timestamp = value
+            (self).timestamp = _cast(value, lambda: unicode)
 
         if ((name) == (u"subtype")):
-            (self).subtype = value
+            (self).subtype = _cast(value, lambda: unicode)
 
         if ((name) == (u"hidden")):
-            (self).hidden = value
+            (self).hidden = _cast(value, lambda: bool)
 
         if ((name) == (u"text")):
-            (self).text = value
+            (self).text = _cast(value, lambda: unicode)
 
         if ((name) == (u"edited")):
-            (self).edited = value
+            (self).edited = _cast(value, lambda: Edited)
 
 
 Message.slack_event_Message_ref = slackpack_md.Root.slack_event_Message_md
@@ -266,10 +266,10 @@ class Edited(object):
 
     def _setField(self, name, value):
         if ((name) == (u"user")):
-            (self).user = value
+            (self).user = _cast(value, lambda: slack.User)
 
         if ((name) == (u"timestamp")):
-            (self).timestamp = value
+            (self).timestamp = _cast(value, lambda: unicode)
 
 
 Edited.slack_event_Edited_ref = slackpack_md.Root.slack_event_Edited_md

--- a/quarkc/test/ffi/expected/py/slackpack/slackpack_md/__init__.py
+++ b/quarkc/test/ffi/expected/py/slackpack/slackpack_md/__init__.py
@@ -11,12 +11,12 @@ class slack_event_SlackEvent_load_Method(quark.reflect.Method):
         super(slack_event_SlackEvent_load_Method, self).__init__(u"quark.void", u"load", _List([u"slack.Client", u"quark.JSONObject"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).load((args)[0], (args)[1]);
+        obj = _cast(object, lambda: slack.event.SlackEvent);
+        (obj).load(_cast((args)[0], lambda: slack.Client), _cast((args)[1], lambda: _JSONObject));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -32,12 +32,12 @@ class slack_event_SlackEvent_dispatch_Method(quark.reflect.Method):
         super(slack_event_SlackEvent_dispatch_Method, self).__init__(u"quark.void", u"dispatch", _List([u"slack.SlackHandler"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).dispatch((args)[0]);
+        obj = _cast(object, lambda: slack.event.SlackEvent);
+        (obj).dispatch(_cast((args)[0], lambda: slack.SlackHandler));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -60,7 +60,7 @@ class slack_event_SlackEvent(quark.reflect.Class):
         return slack.event.SlackEvent()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -77,12 +77,12 @@ class slack_event_SlackError_load_Method(quark.reflect.Method):
         super(slack_event_SlackError_load_Method, self).__init__(u"quark.void", u"load", _List([u"slack.Client", u"quark.JSONObject"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).load((args)[0], (args)[1]);
+        obj = _cast(object, lambda: slack.event.SlackError);
+        (obj).load(_cast((args)[0], lambda: slack.Client), _cast((args)[1], lambda: _JSONObject));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -98,12 +98,12 @@ class slack_event_SlackError_dispatch_Method(quark.reflect.Method):
         super(slack_event_SlackError_dispatch_Method, self).__init__(u"quark.void", u"dispatch", _List([u"slack.SlackHandler"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).dispatch((args)[0]);
+        obj = _cast(object, lambda: slack.event.SlackError);
+        (obj).dispatch(_cast((args)[0], lambda: slack.SlackHandler));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -126,7 +126,7 @@ class slack_event_SlackError(quark.reflect.Class):
         return slack.event.SlackError()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -143,12 +143,12 @@ class slack_event_Hello_dispatch_Method(quark.reflect.Method):
         super(slack_event_Hello_dispatch_Method, self).__init__(u"quark.void", u"dispatch", _List([u"slack.SlackHandler"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).dispatch((args)[0]);
+        obj = _cast(object, lambda: slack.event.Hello);
+        (obj).dispatch(_cast((args)[0], lambda: slack.SlackHandler));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -164,12 +164,12 @@ class slack_event_Hello_load_Method(quark.reflect.Method):
         super(slack_event_Hello_load_Method, self).__init__(u"quark.void", u"load", _List([u"slack.Client", u"quark.JSONObject"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).load((args)[0], (args)[1]);
+        obj = _cast(object, lambda: slack.event.Hello);
+        (obj).load(_cast((args)[0], lambda: slack.Client), _cast((args)[1], lambda: _JSONObject));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -192,7 +192,7 @@ class slack_event_Hello(quark.reflect.Class):
         return slack.event.Hello()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -209,12 +209,12 @@ class slack_event_Message_load_Method(quark.reflect.Method):
         super(slack_event_Message_load_Method, self).__init__(u"quark.void", u"load", _List([u"slack.Client", u"quark.JSONObject"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).load((args)[0], (args)[1]);
+        obj = _cast(object, lambda: slack.event.Message);
+        (obj).load(_cast((args)[0], lambda: slack.Client), _cast((args)[1], lambda: _JSONObject));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -230,12 +230,12 @@ class slack_event_Message_dispatch_Method(quark.reflect.Method):
         super(slack_event_Message_dispatch_Method, self).__init__(u"quark.void", u"dispatch", _List([u"slack.SlackHandler"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).dispatch((args)[0]);
+        obj = _cast(object, lambda: slack.event.Message);
+        (obj).dispatch(_cast((args)[0], lambda: slack.SlackHandler));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -258,7 +258,7 @@ class slack_event_Message(quark.reflect.Class):
         return slack.event.Message()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -282,7 +282,7 @@ class slack_event_Edited(quark.reflect.Class):
         return slack.event.Edited()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -299,12 +299,12 @@ class slack_SlackHandler_onSlackEvent_Method(quark.reflect.Method):
         super(slack_SlackHandler_onSlackEvent_Method, self).__init__(u"quark.void", u"onSlackEvent", _List([u"slack.event.SlackEvent"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onSlackEvent((args)[0]);
+        obj = _cast(object, lambda: slack.SlackHandler);
+        (obj).onSlackEvent(_cast((args)[0], lambda: slack.event.SlackEvent));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -320,12 +320,12 @@ class slack_SlackHandler_onHello_Method(quark.reflect.Method):
         super(slack_SlackHandler_onHello_Method, self).__init__(u"quark.void", u"onHello", _List([u"slack.event.Hello"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onHello((args)[0]);
+        obj = _cast(object, lambda: slack.SlackHandler);
+        (obj).onHello(_cast((args)[0], lambda: slack.event.Hello));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -341,12 +341,12 @@ class slack_SlackHandler_onSlackError_Method(quark.reflect.Method):
         super(slack_SlackHandler_onSlackError_Method, self).__init__(u"quark.void", u"onSlackError", _List([u"slack.event.SlackError"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onSlackError((args)[0]);
+        obj = _cast(object, lambda: slack.SlackHandler);
+        (obj).onSlackError(_cast((args)[0], lambda: slack.event.SlackError));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -362,12 +362,12 @@ class slack_SlackHandler_onMessage_Method(quark.reflect.Method):
         super(slack_SlackHandler_onMessage_Method, self).__init__(u"quark.void", u"onMessage", _List([u"slack.event.Message"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onMessage((args)[0]);
+        obj = _cast(object, lambda: slack.SlackHandler);
+        (obj).onMessage(_cast((args)[0], lambda: slack.event.Message));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -390,7 +390,7 @@ class slack_SlackHandler(quark.reflect.Class):
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -411,10 +411,10 @@ class slack_User(quark.reflect.Class):
         (self).methods = _List([])
 
     def construct(self, args):
-        return slack.User((args)[0], (args)[1])
+        return slack.User(_cast((args)[0], lambda: slack.Client), _cast((args)[1], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -431,12 +431,12 @@ class slack_Channel_send_Method(quark.reflect.Method):
         super(slack_Channel_send_Method, self).__init__(u"quark.void", u"send", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).send((args)[0]);
+        obj = _cast(object, lambda: slack.Channel);
+        (obj).send(_cast((args)[0], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -456,10 +456,10 @@ class slack_Channel(quark.reflect.Class):
         (self).methods = _List([slack_Channel_send_Method()])
 
     def construct(self, args):
-        return slack.Channel((args)[0], (args)[1])
+        return slack.Channel(_cast((args)[0], lambda: slack.Client), _cast((args)[1], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -476,12 +476,12 @@ class slack_Client_connect_Method(quark.reflect.Method):
         super(slack_Client_connect_Method, self).__init__(u"quark.void", u"connect", _List([]));
 
     def invoke(self, object, args):
-        obj = object;
+        obj = _cast(object, lambda: slack.Client);
         (obj).connect();
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -497,12 +497,12 @@ class slack_Client_request_Method(quark.reflect.Method):
         super(slack_Client_request_Method, self).__init__(u"quark.void", u"request", _List([u"quark.String", u"quark.Map<quark.String,quark.Object>", u"quark.HTTPHandler"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).request((args)[0], (args)[1], (args)[2]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).request(_cast((args)[0], lambda: unicode), _cast((args)[1], lambda: _Map), _cast((args)[2], lambda: quark.HTTPHandler));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -518,12 +518,12 @@ class slack_Client_ws_connect_Method(quark.reflect.Method):
         super(slack_Client_ws_connect_Method, self).__init__(u"quark.void", u"ws_connect", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).ws_connect((args)[0]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).ws_connect(_cast((args)[0], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -539,12 +539,12 @@ class slack_Client_ws_send_Method(quark.reflect.Method):
         super(slack_Client_ws_send_Method, self).__init__(u"quark.void", u"ws_send", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).ws_send((args)[0]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).ws_send(_cast((args)[0], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -560,12 +560,12 @@ class slack_Client_onWSConnected_Method(quark.reflect.Method):
         super(slack_Client_onWSConnected_Method, self).__init__(u"quark.void", u"onWSConnected", _List([u"quark.WebSocket"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onWSConnected((args)[0]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).onWSConnected(_cast((args)[0], lambda: quark.WebSocket));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -581,12 +581,12 @@ class slack_Client_onWSClose_Method(quark.reflect.Method):
         super(slack_Client_onWSClose_Method, self).__init__(u"quark.void", u"onWSClose", _List([u"quark.WebSocket"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onWSClose((args)[0]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).onWSClose(_cast((args)[0], lambda: quark.WebSocket));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -602,12 +602,12 @@ class slack_Client_onWSError_Method(quark.reflect.Method):
         super(slack_Client_onWSError_Method, self).__init__(u"quark.void", u"onWSError", _List([u"quark.WebSocket"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onWSError((args)[0]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).onWSError(_cast((args)[0], lambda: quark.WebSocket));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -623,11 +623,11 @@ class slack_Client_construct_Method(quark.reflect.Method):
         super(slack_Client_construct_Method, self).__init__(u"slack.event.SlackEvent", u"construct", _List([u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        return (obj).construct((args)[0])
+        obj = _cast(object, lambda: slack.Client);
+        return (obj).construct(_cast((args)[0], lambda: unicode))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -643,12 +643,12 @@ class slack_Client_onWSMessage_Method(quark.reflect.Method):
         super(slack_Client_onWSMessage_Method, self).__init__(u"quark.void", u"onWSMessage", _List([u"quark.WebSocket", u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onWSMessage((args)[0], (args)[1]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).onWSMessage(_cast((args)[0], lambda: quark.WebSocket), _cast((args)[1], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -664,12 +664,12 @@ class slack_Client_onHTTPResponse_Method(quark.reflect.Method):
         super(slack_Client_onHTTPResponse_Method, self).__init__(u"quark.void", u"onHTTPResponse", _List([u"quark.HTTPRequest", u"quark.HTTPResponse"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onHTTPResponse((args)[0], (args)[1]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).onHTTPResponse(_cast((args)[0], lambda: quark.HTTPRequest), _cast((args)[1], lambda: quark.HTTPResponse));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -685,12 +685,12 @@ class slack_Client_onWSInit_Method(quark.reflect.Method):
         super(slack_Client_onWSInit_Method, self).__init__(u"quark.void", u"onWSInit", _List([u"quark.WebSocket"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onWSInit((args)[0]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).onWSInit(_cast((args)[0], lambda: quark.WebSocket));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -706,12 +706,12 @@ class slack_Client_onWSBinary_Method(quark.reflect.Method):
         super(slack_Client_onWSBinary_Method, self).__init__(u"quark.void", u"onWSBinary", _List([u"quark.WebSocket", u"quark.Buffer"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onWSBinary((args)[0], (args)[1]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).onWSBinary(_cast((args)[0], lambda: quark.WebSocket), (args)[1]);
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -727,12 +727,12 @@ class slack_Client_onWSClosed_Method(quark.reflect.Method):
         super(slack_Client_onWSClosed_Method, self).__init__(u"quark.void", u"onWSClosed", _List([u"quark.WebSocket"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onWSClosed((args)[0]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).onWSClosed(_cast((args)[0], lambda: quark.WebSocket));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -748,12 +748,12 @@ class slack_Client_onWSFinal_Method(quark.reflect.Method):
         super(slack_Client_onWSFinal_Method, self).__init__(u"quark.void", u"onWSFinal", _List([u"quark.WebSocket"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onWSFinal((args)[0]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).onWSFinal(_cast((args)[0], lambda: quark.WebSocket));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -769,12 +769,12 @@ class slack_Client_onHTTPInit_Method(quark.reflect.Method):
         super(slack_Client_onHTTPInit_Method, self).__init__(u"quark.void", u"onHTTPInit", _List([u"quark.HTTPRequest"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onHTTPInit((args)[0]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).onHTTPInit(_cast((args)[0], lambda: quark.HTTPRequest));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -790,12 +790,12 @@ class slack_Client_onHTTPError_Method(quark.reflect.Method):
         super(slack_Client_onHTTPError_Method, self).__init__(u"quark.void", u"onHTTPError", _List([u"quark.HTTPRequest", u"quark.String"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onHTTPError((args)[0], (args)[1]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).onHTTPError(_cast((args)[0], lambda: quark.HTTPRequest), _cast((args)[1], lambda: unicode));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -811,12 +811,12 @@ class slack_Client_onHTTPFinal_Method(quark.reflect.Method):
         super(slack_Client_onHTTPFinal_Method, self).__init__(u"quark.void", u"onHTTPFinal", _List([u"quark.HTTPRequest"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onHTTPFinal((args)[0]);
+        obj = _cast(object, lambda: slack.Client);
+        (obj).onHTTPFinal(_cast((args)[0], lambda: quark.HTTPRequest));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -836,10 +836,10 @@ class slack_Client(quark.reflect.Class):
         (self).methods = _List([slack_Client_connect_Method(), slack_Client_request_Method(), slack_Client_ws_connect_Method(), slack_Client_ws_send_Method(), slack_Client_onWSConnected_Method(), slack_Client_onWSClose_Method(), slack_Client_onWSError_Method(), slack_Client_construct_Method(), slack_Client_onWSMessage_Method(), slack_Client_onHTTPResponse_Method(), slack_Client_onWSInit_Method(), slack_Client_onWSBinary_Method(), slack_Client_onWSClosed_Method(), slack_Client_onWSFinal_Method(), slack_Client_onHTTPInit_Method(), slack_Client_onHTTPError_Method(), slack_Client_onHTTPFinal_Method()])
 
     def construct(self, args):
-        return slack.Client((args)[0], (args)[1], (args)[2])
+        return slack.Client(_cast((args)[0], lambda: quark.Runtime), _cast((args)[1], lambda: unicode), _cast((args)[2], lambda: slack.SlackHandler))
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -856,12 +856,12 @@ class slackpack_Handler_onSlackEvent_Method(quark.reflect.Method):
         super(slackpack_Handler_onSlackEvent_Method, self).__init__(u"quark.void", u"onSlackEvent", _List([u"slack.event.SlackEvent"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onSlackEvent((args)[0]);
+        obj = _cast(object, lambda: slackpack.Handler);
+        (obj).onSlackEvent(_cast((args)[0], lambda: slack.event.SlackEvent));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -877,12 +877,12 @@ class slackpack_Handler_onHello_Method(quark.reflect.Method):
         super(slackpack_Handler_onHello_Method, self).__init__(u"quark.void", u"onHello", _List([u"slack.event.Hello"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onHello((args)[0]);
+        obj = _cast(object, lambda: slackpack.Handler);
+        (obj).onHello(_cast((args)[0], lambda: slack.event.Hello));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -898,12 +898,12 @@ class slackpack_Handler_onSlackError_Method(quark.reflect.Method):
         super(slackpack_Handler_onSlackError_Method, self).__init__(u"quark.void", u"onSlackError", _List([u"slack.event.SlackError"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onSlackError((args)[0]);
+        obj = _cast(object, lambda: slackpack.Handler);
+        (obj).onSlackError(_cast((args)[0], lambda: slack.event.SlackError));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -919,12 +919,12 @@ class slackpack_Handler_onMessage_Method(quark.reflect.Method):
         super(slackpack_Handler_onMessage_Method, self).__init__(u"quark.void", u"onMessage", _List([u"slack.event.Message"]));
 
     def invoke(self, object, args):
-        obj = object;
-        (obj).onMessage((args)[0]);
+        obj = _cast(object, lambda: slackpack.Handler);
+        (obj).onMessage(_cast((args)[0], lambda: slack.event.Message));
         return None
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -947,7 +947,7 @@ class slackpack_Handler(quark.reflect.Class):
         return slackpack.Handler()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -971,7 +971,7 @@ class quark_Map_quark_String_quark_Object_(quark.reflect.Class):
         return _Map()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None
@@ -986,7 +986,7 @@ class Root(object):
     def __init__(self): self._init()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None

--- a/quarkc/test/ffi/expected/py/test/testlib/__init__.py
+++ b/quarkc/test/ffi/expected/py/test/testlib/__init__.py
@@ -3,8 +3,8 @@ from quark_runtime import *
 
 
 def atest():
-    return None
+    return _cast(None, lambda: unicode)
 
 
 def foo():
-    return None
+    return _cast(None, lambda: unicode)

--- a/quarkc/test/ffi/expected/py/test/testlib_md/__init__.py
+++ b/quarkc/test/ffi/expected/py/test/testlib_md/__init__.py
@@ -7,7 +7,7 @@ class Root(object):
     def __init__(self): self._init()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None

--- a/quarkc/test/ffi/expected/py/use/puse_md/__init__.py
+++ b/quarkc/test/ffi/expected/py/use/puse_md/__init__.py
@@ -7,7 +7,7 @@ class Root(object):
     def __init__(self): self._init()
 
     def _getClass(self):
-        return None
+        return _cast(None, lambda: unicode)
 
     def _getField(self, name):
         return None

--- a/quarkc/test/ffi/expected/rb/dependencies/lib/dependencies_md.rb
+++ b/quarkc/test/ffi/expected/rb/dependencies/lib/dependencies_md.rb
@@ -18,7 +18,7 @@ class Root < ::DatawireQuarkCore::QuarkObject
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end

--- a/quarkc/test/ffi/expected/rb/org_example_foo/lib/org_example_foo_md.rb
+++ b/quarkc/test/ffi/expected/rb/org_example_foo/lib/org_example_foo_md.rb
@@ -22,7 +22,7 @@ class OrgExampleFooFooTestMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.org.example.foo.Foo }
         obj.test()
         return nil
 
@@ -31,7 +31,7 @@ class OrgExampleFooFooTestMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -91,7 +91,7 @@ class OrgExampleFooFoo < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -141,7 +141,7 @@ class Root < ::DatawireQuarkCore::QuarkObject
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end

--- a/quarkc/test/ffi/expected/rb/overlapping_namespaces/lib/overlapping_namespace_md.rb
+++ b/quarkc/test/ffi/expected/rb/overlapping_namespaces/lib/overlapping_namespace_md.rb
@@ -22,7 +22,7 @@ class OrgExampleBarBarTestMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.org.example.bar.Bar }
         obj.test()
         return nil
 
@@ -31,7 +31,7 @@ class OrgExampleBarBarTestMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -91,7 +91,7 @@ class OrgExampleBarBar < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -141,7 +141,7 @@ class Root < ::DatawireQuarkCore::QuarkObject
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end

--- a/quarkc/test/ffi/expected/rb/package/lib/package_md.rb
+++ b/quarkc/test/ffi/expected/rb/package/lib/package_md.rb
@@ -23,7 +23,7 @@ class TestTestGoMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.test.Test }
         obj.go()
         return nil
 
@@ -32,7 +32,7 @@ class TestTestGoMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -92,7 +92,7 @@ class TestTest < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -140,7 +140,7 @@ class TestSubtestTestGoMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.test.subtest.Test }
         obj.go()
         return nil
 
@@ -149,7 +149,7 @@ class TestSubtestTestGoMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -209,7 +209,7 @@ class TestSubtestTest < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -260,7 +260,7 @@ class Root < ::DatawireQuarkCore::QuarkObject
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end

--- a/quarkc/test/ffi/expected/rb/package/lib/test.rb
+++ b/quarkc/test/ffi/expected/rb/package/lib/test.rb
@@ -60,7 +60,7 @@ class Test < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("name"))
-            (self).name = value
+            (self).name = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil

--- a/quarkc/test/ffi/expected/rb/package/lib/test/subtest.rb
+++ b/quarkc/test/ffi/expected/rb/package/lib/test/subtest.rb
@@ -61,7 +61,7 @@ class Test < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("size"))
-            (self).size = value
+            (self).size = ::DatawireQuarkCore.cast(value) { ::Integer }
         end
 
         nil

--- a/quarkc/test/ffi/expected/rb/signatures/lib/classes.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/classes.rb
@@ -28,14 +28,14 @@ class Overload < ::DatawireQuarkCore::QuarkObject
 
     def __add__(o)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.Overload }
 
         nil
     end
 
     def __mul__(o)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.Overload }
 
         nil
     end
@@ -67,7 +67,7 @@ class Overload < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("name"))
-            (self).name = value
+            (self).name = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -215,7 +215,7 @@ class TestSize < ::Quark.classes.string_test
 
     def does(expected)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_size }
 
         nil
     end
@@ -240,7 +240,7 @@ class TestSize < ::Quark.classes.string_test
     def _setField(name, value)
         
         if ((name) == ("what"))
-            (self).what = value
+            (self).what = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -279,14 +279,14 @@ class TestStartsWith < ::Quark.classes.string_test
 
     def that(_that)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_startsWith }
 
         nil
     end
 
     def does(expected)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_startsWith }
 
         nil
     end
@@ -314,10 +314,10 @@ class TestStartsWith < ::Quark.classes.string_test
     def _setField(name, value)
         
         if ((name) == ("what"))
-            (self).what = value
+            (self).what = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("_that"))
-            (self)._that = value
+            (self)._that = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -357,14 +357,14 @@ class TestEndsWith < ::Quark.classes.string_test
 
     def that(_that)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_endsWith }
 
         nil
     end
 
     def does(expected)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_endsWith }
 
         nil
     end
@@ -392,10 +392,10 @@ class TestEndsWith < ::Quark.classes.string_test
     def _setField(name, value)
         
         if ((name) == ("what"))
-            (self).what = value
+            (self).what = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("_that"))
-            (self)._that = value
+            (self)._that = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -435,14 +435,14 @@ class TestFind < ::Quark.classes.string_test
 
     def that(_that)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_find }
 
         nil
     end
 
     def does(expected)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_find }
 
         nil
     end
@@ -470,10 +470,10 @@ class TestFind < ::Quark.classes.string_test
     def _setField(name, value)
         
         if ((name) == ("what"))
-            (self).what = value
+            (self).what = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("_that"))
-            (self)._that = value
+            (self)._that = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -513,14 +513,14 @@ class TestSubstring < ::Quark.classes.string_test
 
     def that(start, end_)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_substring }
 
         nil
     end
 
     def does(expected)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_substring }
 
         nil
     end
@@ -551,13 +551,13 @@ class TestSubstring < ::Quark.classes.string_test
     def _setField(name, value)
         
         if ((name) == ("what"))
-            (self).what = value
+            (self).what = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("start"))
-            (self).start = value
+            (self).start = ::DatawireQuarkCore.cast(value) { ::Integer }
         end
         if ((name) == ("end"))
-            (self).end_ = value
+            (self).end_ = ::DatawireQuarkCore.cast(value) { ::Integer }
         end
 
         nil
@@ -598,14 +598,14 @@ class TestReplace < ::Quark.classes.string_test
 
     def that(start, end_)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_replace }
 
         nil
     end
 
     def does(expected)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_replace }
 
         nil
     end
@@ -636,13 +636,13 @@ class TestReplace < ::Quark.classes.string_test
     def _setField(name, value)
         
         if ((name) == ("what"))
-            (self).what = value
+            (self).what = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("start"))
-            (self).start = value
+            (self).start = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("end"))
-            (self).end_ = value
+            (self).end_ = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -683,21 +683,21 @@ class TestJoin < ::Quark.classes.string_test
 
     def that()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_join }
 
         nil
     end
 
     def a(part)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_join }
 
         nil
     end
 
     def does(expected)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_join }
 
         nil
     end
@@ -731,16 +731,16 @@ class TestJoin < ::Quark.classes.string_test
     def _setField(name, value)
         
         if ((name) == ("what"))
-            (self).what = value
+            (self).what = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("parts"))
-            (self).parts = value
+            (self).parts = ::DatawireQuarkCore.cast(value) { ::DatawireQuarkCore::List }
         end
         if ((name) == ("strparts"))
-            (self).strparts = value
+            (self).strparts = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("sep"))
-            (self).sep = value
+            (self).sep = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -782,14 +782,14 @@ class TestSplit < ::Quark.classes.string_test
 
     def that(what)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_split }
 
         nil
     end
 
     def does(expected)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.test_split }
 
         nil
     end
@@ -820,13 +820,13 @@ class TestSplit < ::Quark.classes.string_test
     def _setField(name, value)
         
         if ((name) == ("what"))
-            (self).what = value
+            (self).what = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("sep"))
-            (self).sep = value
+            (self).sep = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("altsep"))
-            (self).altsep = value
+            (self).altsep = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil

--- a/quarkc/test/ffi/expected/rb/signatures/lib/classes/stuff.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/classes/stuff.rb
@@ -27,7 +27,7 @@ class Test < ::DatawireQuarkCore::QuarkObject
 
     def foo(t)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.classes.stuff.Test }
 
         nil
     end

--- a/quarkc/test/ffi/expected/rb/signatures/lib/docs.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/docs.rb
@@ -51,7 +51,7 @@ class Test < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("name"))
-            (self).name = value
+            (self).name = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil

--- a/quarkc/test/ffi/expected/rb/signatures/lib/functions.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/functions.rb
@@ -5,7 +5,7 @@ module Functions
 
 def self.factorial(n)
     
-    return nil
+    return ::DatawireQuarkCore.cast(nil) { ::Integer }
 
 
     nil

--- a/quarkc/test/ffi/expected/rb/signatures/lib/generics.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/generics.rb
@@ -33,7 +33,7 @@ class Box < ::DatawireQuarkCore::QuarkObject
 
     def get()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.T }
 
         nil
     end
@@ -58,7 +58,7 @@ class Box < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("contents"))
-            (self).contents = value
+            (self).contents = ::DatawireQuarkCore.cast(value) { ::Quark.T }
         end
 
         nil
@@ -103,7 +103,7 @@ class Crate < ::DatawireQuarkCore::QuarkObject
 
     def get()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.T }
 
         nil
     end
@@ -131,10 +131,10 @@ class Crate < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("box"))
-            (self).box = value
+            (self).box = ::DatawireQuarkCore.cast(value) { ::Quark.generics.Box }
         end
         if ((name) == ("ibox"))
-            (self).ibox = value
+            (self).ibox = ::DatawireQuarkCore.cast(value) { ::Quark.generics.Box }
         end
 
         nil
@@ -190,7 +190,7 @@ class Sack < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("ints"))
-            (self).ints = value
+            (self).ints = ::DatawireQuarkCore.cast(value) { ::Quark.generics.Box }
         end
 
         nil
@@ -230,7 +230,7 @@ class Matrix < ::DatawireQuarkCore::QuarkObject
 
     def __get__(i, j)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.T }
 
         nil
     end
@@ -268,13 +268,13 @@ class Matrix < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("width"))
-            (self).width = value
+            (self).width = ::DatawireQuarkCore.cast(value) { ::Integer }
         end
         if ((name) == ("height"))
-            (self).height = value
+            (self).height = ::DatawireQuarkCore.cast(value) { ::Integer }
         end
         if ((name) == ("columns"))
-            (self).columns = value
+            (self).columns = ::DatawireQuarkCore.cast(value) { ::DatawireQuarkCore::List }
         end
 
         nil

--- a/quarkc/test/ffi/expected/rb/signatures/lib/generics/ccc.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/generics/ccc.rb
@@ -27,7 +27,7 @@ class TLSContextInitializer < ::DatawireQuarkCore::QuarkObject
 
     def getValue()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.generics.ccc.Context }
 
         nil
     end
@@ -87,14 +87,14 @@ class Context < ::DatawireQuarkCore::QuarkObject
 
     def self.current()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.generics.ccc.Context }
 
         nil
     end
 
     def self.global()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.generics.ccc.Context }
 
         nil
     end
@@ -125,13 +125,13 @@ class Context < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("_global"))
-            ::Quark.generics.ccc.Context._global = value
+            ::Quark.generics.ccc.Context._global = ::DatawireQuarkCore.cast(value) { ::Quark.generics.ccc.Context }
         end
         if ((name) == ("_current"))
-            ::Quark.generics.ccc.Context._current = value
+            ::Quark.generics.ccc.Context._current = ::DatawireQuarkCore.cast(value) { ::Quark.generics.ccc.TLS }
         end
         if ((name) == ("parent"))
-            (self).parent = value
+            (self).parent = ::DatawireQuarkCore.cast(value) { ::Quark.generics.ccc.Context }
         end
 
         nil
@@ -166,7 +166,7 @@ class TLSInitializer < ::DatawireQuarkCore::QuarkObject
 
 
     def getValue()
-        raise NotImplementedError, "this is an abstract method"
+        raise NotImplementedError, '`TLSInitializer.getValue` is an abstract method'
 
         nil
     end
@@ -199,7 +199,7 @@ class TLS < ::DatawireQuarkCore::QuarkObject
 
     def getValue()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.T }
 
         nil
     end
@@ -224,7 +224,7 @@ class TLS < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("_value"))
-            (self)._value = value
+            (self)._value = ::DatawireQuarkCore.cast(value) { ::Quark.T }
         end
 
         nil

--- a/quarkc/test/ffi/expected/rb/signatures/lib/generics/constructors.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/generics/constructors.rb
@@ -29,7 +29,7 @@ class Box < ::DatawireQuarkCore::QuarkObject
 
     def get()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.T }
 
         nil
     end
@@ -54,7 +54,7 @@ class Box < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("contents"))
-            (self).contents = value
+            (self).contents = ::DatawireQuarkCore.cast(value) { ::Quark.T }
         end
 
         nil

--- a/quarkc/test/ffi/expected/rb/signatures/lib/generics/pkg.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/generics/pkg.rb
@@ -27,13 +27,13 @@ class Foo < ::DatawireQuarkCore::QuarkObject
 
     def foo()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.T }
 
         nil
     end
 
     def get()
-        raise NotImplementedError, "this is an abstract method"
+        raise NotImplementedError, '`Foo.get` is an abstract method'
 
         nil
     end
@@ -67,7 +67,7 @@ class StringFoo < ::DatawireQuarkCore::QuarkObject
 
     def get()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -95,7 +95,7 @@ class StringFoo < ::DatawireQuarkCore::QuarkObject
 
     def foo()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -146,7 +146,7 @@ class Box < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("contents"))
-            (self).contents = value
+            (self).contents = ::DatawireQuarkCore.cast(value) { ::Quark.T }
         end
 
         nil
@@ -201,7 +201,7 @@ class StringBox < ::Quark.generics.pkg.Box
     def _setField(name, value)
         
         if ((name) == ("contents"))
-            (self).contents = value
+            (self).contents = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil

--- a/quarkc/test/ffi/expected/rb/signatures/lib/inheritance.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/inheritance.rb
@@ -49,7 +49,7 @@ class Base < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("name"))
-            (self).name = value
+            (self).name = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -111,13 +111,13 @@ class Test < ::Quark.inheritance.Base
     def _setField(name, value)
         
         if ((name) == ("name"))
-            (self).name = value
+            (self).name = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("mumble"))
-            (self).mumble = value
+            (self).mumble = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("later"))
-            (self).later = value
+            (self).later = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -175,7 +175,7 @@ class A < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("name"))
-            (self).name = value
+            (self).name = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -237,7 +237,7 @@ class B < ::Quark.inheritance.A
     def _setField(name, value)
         
         if ((name) == ("name"))
-            (self).name = value
+            (self).name = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -299,7 +299,7 @@ class C < ::Quark.inheritance.A
     def _setField(name, value)
         
         if ((name) == ("name"))
-            (self).name = value
+            (self).name = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -410,7 +410,7 @@ class Y < ::Quark.inheritance.X
     def _setField(name, value)
         
         if ((name) == ("name"))
-            (self).name = value
+            (self).name = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -447,7 +447,7 @@ class Message < ::DatawireQuarkCore::QuarkObject
 
     def encode()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -553,7 +553,7 @@ class Pong < ::Quark.inheritance.Message
 
     def toString()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end

--- a/quarkc/test/ffi/expected/rb/signatures/lib/inheritance/pets.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/inheritance/pets.rb
@@ -23,7 +23,7 @@ class Pet < ::DatawireQuarkCore::QuarkObject
 
 
     def greet()
-        raise NotImplementedError, "this is an abstract method"
+        raise NotImplementedError, '`Pet.greet` is an abstract method'
 
         nil
     end

--- a/quarkc/test/ffi/expected/rb/signatures/lib/inheritance/super_.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/inheritance/super_.rb
@@ -54,7 +54,7 @@ class A < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("name"))
-            (self).name = value
+            (self).name = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -116,7 +116,7 @@ class B < ::Quark.inheritance.super_.A
     def _setField(name, value)
         
         if ((name) == ("name"))
-            (self).name = value
+            (self).name = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil

--- a/quarkc/test/ffi/expected/rb/signatures/lib/inheritance/use_before_def.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/inheritance/use_before_def.rb
@@ -101,7 +101,7 @@ class Foo < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("name"))
-            (self).name = value
+            (self).name = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil

--- a/quarkc/test/ffi/expected/rb/signatures/lib/interfaces.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/interfaces.rb
@@ -24,7 +24,7 @@ class A < ::DatawireQuarkCore::QuarkObject
 
 
     def foo()
-        raise NotImplementedError, "this is an abstract method"
+        raise NotImplementedError, '`A.foo` is an abstract method'
 
         nil
     end
@@ -443,19 +443,19 @@ class Foo < ::DatawireQuarkCore::QuarkObject
 
 
     def m1()
-        raise NotImplementedError, "this is an abstract method"
+        raise NotImplementedError, '`Foo.m1` is an abstract method'
 
         nil
     end
 
     def m2(arg)
-        raise NotImplementedError, "this is an abstract method"
+        raise NotImplementedError, '`Foo.m2` is an abstract method'
 
         nil
     end
 
     def m3(args)
-        raise NotImplementedError, "this is an abstract method"
+        raise NotImplementedError, '`Foo.m3` is an abstract method'
 
         nil
     end
@@ -488,19 +488,19 @@ class Bar < ::DatawireQuarkCore::QuarkObject
 
 
     def m1()
-        raise NotImplementedError, "this is an abstract method"
+        raise NotImplementedError, '`Bar.m1` is an abstract method'
 
         nil
     end
 
     def m2(arg)
-        raise NotImplementedError, "this is an abstract method"
+        raise NotImplementedError, '`Bar.m2` is an abstract method'
 
         nil
     end
 
     def m3(args)
-        raise NotImplementedError, "this is an abstract method"
+        raise NotImplementedError, '`Bar.m3` is an abstract method'
 
         nil
     end

--- a/quarkc/test/ffi/expected/rb/signatures/lib/quark_ffi_signatures_md.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/quark_ffi_signatures_md.rb
@@ -36,7 +36,7 @@ class GenericsBoxQuarkObjectSetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.Box }
         obj.set((args)[0])
         return nil
 
@@ -45,7 +45,7 @@ class GenericsBoxQuarkObjectSetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -91,7 +91,7 @@ class GenericsBoxQuarkObjectGetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.Box }
         return obj.get()
 
         nil
@@ -99,7 +99,7 @@ class GenericsBoxQuarkObjectGetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -159,7 +159,7 @@ class GenericsBoxQuarkObject < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -207,8 +207,8 @@ class GenericsBoxQuarkIntSetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.set((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.Box }
+        obj.set(::DatawireQuarkCore.cast((args)[0]) { ::Integer })
         return nil
 
         nil
@@ -216,7 +216,7 @@ class GenericsBoxQuarkIntSetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -262,7 +262,7 @@ class GenericsBoxQuarkIntGetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.Box }
         return obj.get()
 
         nil
@@ -270,7 +270,7 @@ class GenericsBoxQuarkIntGetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -330,7 +330,7 @@ class GenericsBoxQuarkInt < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -378,7 +378,7 @@ class GenericsCrateQuarkObjectSetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.Crate }
         obj.set((args)[0])
         return nil
 
@@ -387,7 +387,7 @@ class GenericsCrateQuarkObjectSetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -433,7 +433,7 @@ class GenericsCrateQuarkObjectGetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.Crate }
         return obj.get()
 
         nil
@@ -441,7 +441,7 @@ class GenericsCrateQuarkObjectGetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -501,7 +501,7 @@ class GenericsCrateQuarkObject < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -563,7 +563,7 @@ class GenericsSack < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -611,15 +611,15 @@ class GenericsMatrixQuarkObjectGetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.__get__((args)[0], (args)[1])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.Matrix }
+        return obj.__get__(::DatawireQuarkCore.cast((args)[0]) { ::Integer }, ::DatawireQuarkCore.cast((args)[1]) { ::Integer })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -665,8 +665,8 @@ class GenericsMatrixQuarkObjectSetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.__set__((args)[0], (args)[1], (args)[2])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.Matrix }
+        obj.__set__(::DatawireQuarkCore.cast((args)[0]) { ::Integer }, ::DatawireQuarkCore.cast((args)[1]) { ::Integer }, (args)[2])
         return nil
 
         nil
@@ -674,7 +674,7 @@ class GenericsMatrixQuarkObjectSetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -727,14 +727,14 @@ class GenericsMatrixQuarkObject < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.generics.Matrix.new((args)[0], (args)[1])
+        return ::Quark.generics.Matrix.new(::DatawireQuarkCore.cast((args)[0]) { ::Integer }, ::DatawireQuarkCore.cast((args)[1]) { ::Integer })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -782,7 +782,7 @@ class GenericsConstructorsBoxQuarkObjectGetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.constructors.Box }
         return obj.get()
 
         nil
@@ -790,7 +790,7 @@ class GenericsConstructorsBoxQuarkObjectGetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -850,7 +850,7 @@ class GenericsConstructorsBoxQuarkObject < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -898,7 +898,7 @@ class GenericsPkgFooQuarkObjectFooMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.pkg.Foo }
         return obj.foo()
 
         nil
@@ -906,7 +906,7 @@ class GenericsPkgFooQuarkObjectFooMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -952,7 +952,7 @@ class GenericsPkgFooQuarkObjectGetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.pkg.Foo }
         return obj.get()
 
         nil
@@ -960,7 +960,7 @@ class GenericsPkgFooQuarkObjectGetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1020,7 +1020,7 @@ class GenericsPkgFooQuarkObject < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1068,7 +1068,7 @@ class GenericsPkgStringFooGetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.pkg.StringFoo }
         return obj.get()
 
         nil
@@ -1076,7 +1076,7 @@ class GenericsPkgStringFooGetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1122,7 +1122,7 @@ class GenericsPkgStringFooFooMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.pkg.StringFoo }
         return obj.foo()
 
         nil
@@ -1130,7 +1130,7 @@ class GenericsPkgStringFooFooMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1190,7 +1190,7 @@ class GenericsPkgStringFoo < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1245,14 +1245,14 @@ class GenericsPkgBoxQuarkString < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.generics.pkg.Box.new((args)[0])
+        return ::Quark.generics.pkg.Box.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1307,14 +1307,14 @@ class GenericsPkgStringBox < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.generics.pkg.StringBox.new((args)[0])
+        return ::Quark.generics.pkg.StringBox.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1362,7 +1362,7 @@ class GenericsCccTLSContextInitializerGetValueMethod < ::Quark.quark.reflect.Met
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.ccc.TLSContextInitializer }
         return obj.getValue()
 
         nil
@@ -1370,7 +1370,7 @@ class GenericsCccTLSContextInitializerGetValueMethod < ::Quark.quark.reflect.Met
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1430,7 +1430,7 @@ class GenericsCccTLSContextInitializer < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1478,7 +1478,7 @@ class GenericsCccContextCurrentMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.ccc.Context }
         return ::Quark.generics.ccc.Context.current()
 
         nil
@@ -1486,7 +1486,7 @@ class GenericsCccContextCurrentMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1532,7 +1532,7 @@ class GenericsCccContextGlobalMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.ccc.Context }
         return ::Quark.generics.ccc.Context.global()
 
         nil
@@ -1540,7 +1540,7 @@ class GenericsCccContextGlobalMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1593,14 +1593,14 @@ class GenericsCccContext < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.generics.ccc.Context.new((args)[0])
+        return ::Quark.generics.ccc.Context.new(::DatawireQuarkCore.cast((args)[0]) { ::Quark.generics.ccc.Context })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1648,7 +1648,7 @@ class GenericsCccTLSInitializerQuarkObjectGetValueMethod < ::Quark.quark.reflect
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.ccc.TLSInitializer }
         return obj.getValue()
 
         nil
@@ -1656,7 +1656,7 @@ class GenericsCccTLSInitializerQuarkObjectGetValueMethod < ::Quark.quark.reflect
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1716,7 +1716,7 @@ class GenericsCccTLSInitializerQuarkObject < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1764,7 +1764,7 @@ class GenericsCccTLSGenericsCccContextGetValueMethod < ::Quark.quark.reflect.Met
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.generics.ccc.TLS }
         return obj.getValue()
 
         nil
@@ -1772,7 +1772,7 @@ class GenericsCccTLSGenericsCccContextGetValueMethod < ::Quark.quark.reflect.Met
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1825,14 +1825,14 @@ class GenericsCccTLSGenericsCccContext < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.generics.ccc.TLS.new((args)[0])
+        return ::Quark.generics.ccc.TLS.new(::DatawireQuarkCore.cast((args)[0]) { ::Quark.generics.ccc.TLSInitializer })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1894,7 +1894,7 @@ class InheritanceBase < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1956,7 +1956,7 @@ class InheritanceTest < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2011,14 +2011,14 @@ class InheritanceA < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.inheritance.A.new((args)[0])
+        return ::Quark.inheritance.A.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2066,7 +2066,7 @@ class InheritanceBGreetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.B }
         obj.greet()
         return nil
 
@@ -2075,7 +2075,7 @@ class InheritanceBGreetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2128,14 +2128,14 @@ class InheritanceB < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.inheritance.B.new((args)[0])
+        return ::Quark.inheritance.B.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2183,7 +2183,7 @@ class InheritanceCGreetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.C }
         obj.greet()
         return nil
 
@@ -2192,7 +2192,7 @@ class InheritanceCGreetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2245,14 +2245,14 @@ class InheritanceC < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.inheritance.C.new((args)[0])
+        return ::Quark.inheritance.C.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2314,7 +2314,7 @@ class InheritanceX < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2362,7 +2362,7 @@ class InheritanceYTestMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.Y }
         obj.test()
         return nil
 
@@ -2371,7 +2371,7 @@ class InheritanceYTestMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2424,14 +2424,14 @@ class InheritanceY < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.inheritance.Y.new((args)[0])
+        return ::Quark.inheritance.Y.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2479,7 +2479,7 @@ class InheritanceT1AFooMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.t1.A }
         obj.foo()
         return nil
 
@@ -2488,7 +2488,7 @@ class InheritanceT1AFooMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2548,7 +2548,7 @@ class InheritanceT1A < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2596,7 +2596,7 @@ class InheritanceT1BFooMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.t1.B }
         obj.foo()
         return nil
 
@@ -2605,7 +2605,7 @@ class InheritanceT1BFooMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2665,7 +2665,7 @@ class InheritanceT1B < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2713,7 +2713,7 @@ class InheritanceT1CFooMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.t1.C }
         obj.foo()
         return nil
 
@@ -2722,7 +2722,7 @@ class InheritanceT1CFooMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2782,7 +2782,7 @@ class InheritanceT1C < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2844,7 +2844,7 @@ class InheritanceT2A < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2906,7 +2906,7 @@ class InheritanceT2B < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2968,7 +2968,7 @@ class InheritanceT2XQuarkInt < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3030,7 +3030,7 @@ class InheritanceT2Y < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3078,7 +3078,7 @@ class InheritancePetsCatGreetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.pets.Cat }
         obj.greet()
         return nil
 
@@ -3087,7 +3087,7 @@ class InheritancePetsCatGreetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3147,7 +3147,7 @@ class InheritancePetsCat < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3195,7 +3195,7 @@ class InheritancePetsDogGreetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.pets.Dog }
         obj.greet()
         return nil
 
@@ -3204,7 +3204,7 @@ class InheritancePetsDogGreetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3264,7 +3264,7 @@ class InheritancePetsDog < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3312,7 +3312,7 @@ class InheritanceMessageEncodeMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.Message }
         return obj.encode()
 
         nil
@@ -3320,7 +3320,7 @@ class InheritanceMessageEncodeMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3380,7 +3380,7 @@ class InheritanceMessage < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3428,7 +3428,7 @@ class InheritancePingEncodeMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.Ping }
         return obj.encode()
 
         nil
@@ -3436,7 +3436,7 @@ class InheritancePingEncodeMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3496,7 +3496,7 @@ class InheritancePing < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3544,7 +3544,7 @@ class InheritancePongToStringMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.Pong }
         return obj.toString()
 
         nil
@@ -3552,7 +3552,7 @@ class InheritancePongToStringMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3598,7 +3598,7 @@ class InheritancePongEncodeMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.Pong }
         return obj.encode()
 
         nil
@@ -3606,7 +3606,7 @@ class InheritancePongEncodeMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3666,7 +3666,7 @@ class InheritancePong < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3714,7 +3714,7 @@ class InheritanceSuperAGreetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.super_.A }
         obj.greet()
         return nil
 
@@ -3723,7 +3723,7 @@ class InheritanceSuperAGreetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3776,14 +3776,14 @@ class InheritanceSuperA < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.inheritance.super_.A.new((args)[0])
+        return ::Quark.inheritance.super_.A.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3831,7 +3831,7 @@ class InheritanceSuperBGreetMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.super_.B }
         obj.greet()
         return nil
 
@@ -3840,7 +3840,7 @@ class InheritanceSuperBGreetMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3900,7 +3900,7 @@ class InheritanceSuperB < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -3948,7 +3948,7 @@ class InheritanceUseBeforeDefBarGoMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.inheritance.use_before_def.Bar }
         obj.go()
         return nil
 
@@ -3957,7 +3957,7 @@ class InheritanceUseBeforeDefBarGoMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4017,7 +4017,7 @@ class InheritanceUseBeforeDefBar < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4079,7 +4079,7 @@ class InheritanceUseBeforeDefFoo < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4127,7 +4127,7 @@ class InterfacesAFooMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.A }
         obj.foo()
         return nil
 
@@ -4136,7 +4136,7 @@ class InterfacesAFooMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4182,7 +4182,7 @@ class InterfacesABarMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.A }
         obj.bar()
         return nil
 
@@ -4191,7 +4191,7 @@ class InterfacesABarMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4251,7 +4251,7 @@ class InterfacesA < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4299,7 +4299,7 @@ class InterfacesBBarMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.B }
         obj.bar()
         return nil
 
@@ -4308,7 +4308,7 @@ class InterfacesBBarMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4368,7 +4368,7 @@ class InterfacesB < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4416,7 +4416,7 @@ class InterfacesCFooMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.C }
         obj.foo()
         return nil
 
@@ -4425,7 +4425,7 @@ class InterfacesCFooMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4485,7 +4485,7 @@ class InterfacesC < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4533,7 +4533,7 @@ class InterfacesT1FooMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.T1 }
         obj.foo()
         return nil
 
@@ -4542,7 +4542,7 @@ class InterfacesT1FooMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4588,7 +4588,7 @@ class InterfacesT1BarMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.T1 }
         obj.bar()
         return nil
 
@@ -4597,7 +4597,7 @@ class InterfacesT1BarMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4657,7 +4657,7 @@ class InterfacesT1 < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4705,7 +4705,7 @@ class InterfacesT2FooMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.T2 }
         obj.foo()
         return nil
 
@@ -4714,7 +4714,7 @@ class InterfacesT2FooMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4760,7 +4760,7 @@ class InterfacesT2BarMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.T2 }
         obj.bar()
         return nil
 
@@ -4769,7 +4769,7 @@ class InterfacesT2BarMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4829,7 +4829,7 @@ class InterfacesT2 < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4877,7 +4877,7 @@ class InterfacesT3FooMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.T3 }
         obj.foo()
         return nil
 
@@ -4886,7 +4886,7 @@ class InterfacesT3FooMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -4932,7 +4932,7 @@ class InterfacesT3BarMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.T3 }
         obj.bar()
         return nil
 
@@ -4941,7 +4941,7 @@ class InterfacesT3BarMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5001,7 +5001,7 @@ class InterfacesT3 < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5049,7 +5049,7 @@ class InterfacesT4FooMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.T4 }
         obj.foo()
         return nil
 
@@ -5058,7 +5058,7 @@ class InterfacesT4FooMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5104,7 +5104,7 @@ class InterfacesT4BarMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.T4 }
         obj.bar()
         return nil
 
@@ -5113,7 +5113,7 @@ class InterfacesT4BarMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5173,7 +5173,7 @@ class InterfacesT4 < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5221,7 +5221,7 @@ class InterfacesT5FooMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.T5 }
         obj.foo()
         return nil
 
@@ -5230,7 +5230,7 @@ class InterfacesT5FooMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5276,7 +5276,7 @@ class InterfacesT5BarMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.T5 }
         obj.bar()
         return nil
 
@@ -5285,7 +5285,7 @@ class InterfacesT5BarMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5345,7 +5345,7 @@ class InterfacesT5 < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5393,7 +5393,7 @@ class InterfacesFooM1Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.Foo }
         obj.m1()
         return nil
 
@@ -5402,7 +5402,7 @@ class InterfacesFooM1Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5448,8 +5448,8 @@ class InterfacesFooM2Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.m2((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.Foo }
+        obj.m2(::DatawireQuarkCore.cast((args)[0]) { ::Integer })
         return nil
 
         nil
@@ -5457,7 +5457,7 @@ class InterfacesFooM2Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5503,8 +5503,8 @@ class InterfacesFooM3Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.m3((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.Foo }
+        obj.m3(::DatawireQuarkCore.cast((args)[0]) { ::DatawireQuarkCore::List })
         return nil
 
         nil
@@ -5512,7 +5512,7 @@ class InterfacesFooM3Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5572,7 +5572,7 @@ class InterfacesFoo < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5620,7 +5620,7 @@ class InterfacesBarQuarkObjectM1Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.Bar }
         obj.m1()
         return nil
 
@@ -5629,7 +5629,7 @@ class InterfacesBarQuarkObjectM1Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5675,7 +5675,7 @@ class InterfacesBarQuarkObjectM2Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.Bar }
         obj.m2((args)[0])
         return nil
 
@@ -5684,7 +5684,7 @@ class InterfacesBarQuarkObjectM2Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5730,8 +5730,8 @@ class InterfacesBarQuarkObjectM3Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.m3((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.Bar }
+        obj.m3(::DatawireQuarkCore.cast((args)[0]) { ::DatawireQuarkCore::List })
         return nil
 
         nil
@@ -5739,7 +5739,7 @@ class InterfacesBarQuarkObjectM3Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5799,7 +5799,7 @@ class InterfacesBarQuarkObject < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5847,8 +5847,8 @@ class InterfacesBazM2Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.m2((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.Baz }
+        obj.m2(::DatawireQuarkCore.cast((args)[0]) { ::Integer })
         return nil
 
         nil
@@ -5856,7 +5856,7 @@ class InterfacesBazM2Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5902,7 +5902,7 @@ class InterfacesBazM1Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.Baz }
         obj.m1()
         return nil
 
@@ -5911,7 +5911,7 @@ class InterfacesBazM1Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -5957,8 +5957,8 @@ class InterfacesBazM3Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.m3((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.Baz }
+        obj.m3(::DatawireQuarkCore.cast((args)[0]) { ::DatawireQuarkCore::List })
         return nil
 
         nil
@@ -5966,7 +5966,7 @@ class InterfacesBazM3Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6026,7 +6026,7 @@ class InterfacesBaz < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6074,7 +6074,7 @@ class InterfacesRazBarM1Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.RazBar }
         obj.m1()
         return nil
 
@@ -6083,7 +6083,7 @@ class InterfacesRazBarM1Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6129,8 +6129,8 @@ class InterfacesRazBarM2Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.m2((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.RazBar }
+        obj.m2(::DatawireQuarkCore.cast((args)[0]) { ::String })
         return nil
 
         nil
@@ -6138,7 +6138,7 @@ class InterfacesRazBarM2Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6184,8 +6184,8 @@ class InterfacesRazBarM3Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.m3((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.RazBar }
+        obj.m3(::DatawireQuarkCore.cast((args)[0]) { ::DatawireQuarkCore::List })
         return nil
 
         nil
@@ -6193,7 +6193,7 @@ class InterfacesRazBarM3Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6253,7 +6253,7 @@ class InterfacesRazBar < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6301,7 +6301,7 @@ class InterfacesRazFazQuarkObjectM1Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.RazFaz }
         obj.m1()
         return nil
 
@@ -6310,7 +6310,7 @@ class InterfacesRazFazQuarkObjectM1Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6356,7 +6356,7 @@ class InterfacesRazFazQuarkObjectM2Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.RazFaz }
         obj.m2((args)[0])
         return nil
 
@@ -6365,7 +6365,7 @@ class InterfacesRazFazQuarkObjectM2Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6411,8 +6411,8 @@ class InterfacesRazFazQuarkObjectM3Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.m3((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.RazFaz }
+        obj.m3(::DatawireQuarkCore.cast((args)[0]) { ::DatawireQuarkCore::List })
         return nil
 
         nil
@@ -6420,7 +6420,7 @@ class InterfacesRazFazQuarkObjectM3Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6480,7 +6480,7 @@ class InterfacesRazFazQuarkObject < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6528,7 +6528,7 @@ class InterfacesBazBarM1Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.BazBar }
         obj.m1()
         return nil
 
@@ -6537,7 +6537,7 @@ class InterfacesBazBarM1Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6583,8 +6583,8 @@ class InterfacesBazBarM2Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.m2((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.BazBar }
+        obj.m2(::DatawireQuarkCore.cast((args)[0]) { ::String })
         return nil
 
         nil
@@ -6592,7 +6592,7 @@ class InterfacesBazBarM2Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6638,8 +6638,8 @@ class InterfacesBazBarM3Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.m3((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.BazBar }
+        obj.m3(::DatawireQuarkCore.cast((args)[0]) { ::DatawireQuarkCore::List })
         return nil
 
         nil
@@ -6647,7 +6647,7 @@ class InterfacesBazBarM3Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6707,7 +6707,7 @@ class InterfacesBazBar < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6755,7 +6755,7 @@ class InterfacesBazFazQuarkObjectM1Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.BazFaz }
         obj.m1()
         return nil
 
@@ -6764,7 +6764,7 @@ class InterfacesBazFazQuarkObjectM1Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6810,7 +6810,7 @@ class InterfacesBazFazQuarkObjectM2Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.BazFaz }
         obj.m2((args)[0])
         return nil
 
@@ -6819,7 +6819,7 @@ class InterfacesBazFazQuarkObjectM2Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6865,8 +6865,8 @@ class InterfacesBazFazQuarkObjectM3Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.m3((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.interfaces.BazFaz }
+        obj.m3(::DatawireQuarkCore.cast((args)[0]) { ::DatawireQuarkCore::List })
         return nil
 
         nil
@@ -6874,7 +6874,7 @@ class InterfacesBazFazQuarkObjectM3Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6934,7 +6934,7 @@ class InterfacesBazFazQuarkObject < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -6982,15 +6982,15 @@ class ClassesOverloadAddMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.__add__((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.Overload }
+        return obj.__add__(::DatawireQuarkCore.cast((args)[0]) { ::Quark.classes.Overload })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7036,15 +7036,15 @@ class ClassesOverloadMulMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.__mul__((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.Overload }
+        return obj.__mul__(::DatawireQuarkCore.cast((args)[0]) { ::Quark.classes.Overload })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7090,7 +7090,7 @@ class ClassesOverloadTestMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.Overload }
         obj.test()
         return nil
 
@@ -7099,7 +7099,7 @@ class ClassesOverloadTestMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7152,14 +7152,14 @@ class ClassesOverload < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.classes.Overload.new((args)[0])
+        return ::Quark.classes.Overload.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7207,7 +7207,7 @@ class ClassesTestTestMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.Test }
         obj.test()
         return nil
 
@@ -7216,7 +7216,7 @@ class ClassesTestTestMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7276,7 +7276,7 @@ class ClassesTest < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7324,8 +7324,8 @@ class ClassesStringTestCheckMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.check((args)[0], (args)[1], (args)[2], (args)[3])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.string_test }
+        obj.check(::DatawireQuarkCore.cast((args)[0]) { ::String }, ::DatawireQuarkCore.cast((args)[1]) { ::String }, ::DatawireQuarkCore.cast((args)[2]) { ::String }, ::DatawireQuarkCore.cast((args)[3]) { ::String })
         return nil
 
         nil
@@ -7333,7 +7333,7 @@ class ClassesStringTestCheckMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7393,7 +7393,7 @@ class ClassesStringTest < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7441,15 +7441,15 @@ class ClassesTestSizeDoesMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.does((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_size }
+        return obj.does(::DatawireQuarkCore.cast((args)[0]) { ::Integer })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7495,8 +7495,8 @@ class ClassesTestSizeCheckMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.check((args)[0], (args)[1], (args)[2], (args)[3])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_size }
+        obj.check(::DatawireQuarkCore.cast((args)[0]) { ::String }, ::DatawireQuarkCore.cast((args)[1]) { ::String }, ::DatawireQuarkCore.cast((args)[2]) { ::String }, ::DatawireQuarkCore.cast((args)[3]) { ::String })
         return nil
 
         nil
@@ -7504,7 +7504,7 @@ class ClassesTestSizeCheckMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7557,14 +7557,14 @@ class ClassesTestSize < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.classes.test_size.new((args)[0])
+        return ::Quark.classes.test_size.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7612,15 +7612,15 @@ class ClassesTestStartsWithThatMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.that((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_startsWith }
+        return obj.that(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7666,15 +7666,15 @@ class ClassesTestStartsWithDoesMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.does((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_startsWith }
+        return obj.does(::DatawireQuarkCore.cast((args)[0]) { ::Object })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7720,8 +7720,8 @@ class ClassesTestStartsWithCheckMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.check((args)[0], (args)[1], (args)[2], (args)[3])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_startsWith }
+        obj.check(::DatawireQuarkCore.cast((args)[0]) { ::String }, ::DatawireQuarkCore.cast((args)[1]) { ::String }, ::DatawireQuarkCore.cast((args)[2]) { ::String }, ::DatawireQuarkCore.cast((args)[3]) { ::String })
         return nil
 
         nil
@@ -7729,7 +7729,7 @@ class ClassesTestStartsWithCheckMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7782,14 +7782,14 @@ class ClassesTestStartsWith < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.classes.test_startsWith.new((args)[0])
+        return ::Quark.classes.test_startsWith.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7837,15 +7837,15 @@ class ClassesTestEndsWithThatMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.that((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_endsWith }
+        return obj.that(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7891,15 +7891,15 @@ class ClassesTestEndsWithDoesMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.does((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_endsWith }
+        return obj.does(::DatawireQuarkCore.cast((args)[0]) { ::Object })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -7945,8 +7945,8 @@ class ClassesTestEndsWithCheckMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.check((args)[0], (args)[1], (args)[2], (args)[3])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_endsWith }
+        obj.check(::DatawireQuarkCore.cast((args)[0]) { ::String }, ::DatawireQuarkCore.cast((args)[1]) { ::String }, ::DatawireQuarkCore.cast((args)[2]) { ::String }, ::DatawireQuarkCore.cast((args)[3]) { ::String })
         return nil
 
         nil
@@ -7954,7 +7954,7 @@ class ClassesTestEndsWithCheckMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8007,14 +8007,14 @@ class ClassesTestEndsWith < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.classes.test_endsWith.new((args)[0])
+        return ::Quark.classes.test_endsWith.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8062,15 +8062,15 @@ class ClassesTestFindThatMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.that((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_find }
+        return obj.that(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8116,15 +8116,15 @@ class ClassesTestFindDoesMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.does((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_find }
+        return obj.does(::DatawireQuarkCore.cast((args)[0]) { ::Integer })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8170,8 +8170,8 @@ class ClassesTestFindCheckMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.check((args)[0], (args)[1], (args)[2], (args)[3])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_find }
+        obj.check(::DatawireQuarkCore.cast((args)[0]) { ::String }, ::DatawireQuarkCore.cast((args)[1]) { ::String }, ::DatawireQuarkCore.cast((args)[2]) { ::String }, ::DatawireQuarkCore.cast((args)[3]) { ::String })
         return nil
 
         nil
@@ -8179,7 +8179,7 @@ class ClassesTestFindCheckMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8232,14 +8232,14 @@ class ClassesTestFind < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.classes.test_find.new((args)[0])
+        return ::Quark.classes.test_find.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8287,15 +8287,15 @@ class ClassesTestSubstringThatMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.that((args)[0], (args)[1])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_substring }
+        return obj.that(::DatawireQuarkCore.cast((args)[0]) { ::Integer }, ::DatawireQuarkCore.cast((args)[1]) { ::Integer })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8341,15 +8341,15 @@ class ClassesTestSubstringDoesMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.does((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_substring }
+        return obj.does(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8395,8 +8395,8 @@ class ClassesTestSubstringCheckMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.check((args)[0], (args)[1], (args)[2], (args)[3])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_substring }
+        obj.check(::DatawireQuarkCore.cast((args)[0]) { ::String }, ::DatawireQuarkCore.cast((args)[1]) { ::String }, ::DatawireQuarkCore.cast((args)[2]) { ::String }, ::DatawireQuarkCore.cast((args)[3]) { ::String })
         return nil
 
         nil
@@ -8404,7 +8404,7 @@ class ClassesTestSubstringCheckMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8457,14 +8457,14 @@ class ClassesTestSubstring < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.classes.test_substring.new((args)[0])
+        return ::Quark.classes.test_substring.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8512,15 +8512,15 @@ class ClassesTestReplaceThatMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.that((args)[0], (args)[1])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_replace }
+        return obj.that(::DatawireQuarkCore.cast((args)[0]) { ::String }, ::DatawireQuarkCore.cast((args)[1]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8566,15 +8566,15 @@ class ClassesTestReplaceDoesMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.does((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_replace }
+        return obj.does(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8620,8 +8620,8 @@ class ClassesTestReplaceCheckMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.check((args)[0], (args)[1], (args)[2], (args)[3])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_replace }
+        obj.check(::DatawireQuarkCore.cast((args)[0]) { ::String }, ::DatawireQuarkCore.cast((args)[1]) { ::String }, ::DatawireQuarkCore.cast((args)[2]) { ::String }, ::DatawireQuarkCore.cast((args)[3]) { ::String })
         return nil
 
         nil
@@ -8629,7 +8629,7 @@ class ClassesTestReplaceCheckMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8682,14 +8682,14 @@ class ClassesTestReplace < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.classes.test_replace.new((args)[0])
+        return ::Quark.classes.test_replace.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8737,7 +8737,7 @@ class ClassesTestJoinThatMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_join }
         return obj.that()
 
         nil
@@ -8745,7 +8745,7 @@ class ClassesTestJoinThatMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8791,15 +8791,15 @@ class ClassesTestJoinAMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.a((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_join }
+        return obj.a(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8845,15 +8845,15 @@ class ClassesTestJoinDoesMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.does((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_join }
+        return obj.does(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8899,8 +8899,8 @@ class ClassesTestJoinCheckMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.check((args)[0], (args)[1], (args)[2], (args)[3])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_join }
+        obj.check(::DatawireQuarkCore.cast((args)[0]) { ::String }, ::DatawireQuarkCore.cast((args)[1]) { ::String }, ::DatawireQuarkCore.cast((args)[2]) { ::String }, ::DatawireQuarkCore.cast((args)[3]) { ::String })
         return nil
 
         nil
@@ -8908,7 +8908,7 @@ class ClassesTestJoinCheckMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -8961,14 +8961,14 @@ class ClassesTestJoin < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.classes.test_join.new((args)[0])
+        return ::Quark.classes.test_join.new(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9016,15 +9016,15 @@ class ClassesTestSplitThatMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.that((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_split }
+        return obj.that(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9070,15 +9070,15 @@ class ClassesTestSplitDoesMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.does((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_split }
+        return obj.does(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9124,8 +9124,8 @@ class ClassesTestSplitCheckMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.check((args)[0], (args)[1], (args)[2], (args)[3])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.test_split }
+        obj.check(::DatawireQuarkCore.cast((args)[0]) { ::String }, ::DatawireQuarkCore.cast((args)[1]) { ::String }, ::DatawireQuarkCore.cast((args)[2]) { ::String }, ::DatawireQuarkCore.cast((args)[3]) { ::String })
         return nil
 
         nil
@@ -9133,7 +9133,7 @@ class ClassesTestSplitCheckMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9186,14 +9186,14 @@ class ClassesTestSplit < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.classes.test_split.new((args)[0], (args)[1])
+        return ::Quark.classes.test_split.new(::DatawireQuarkCore.cast((args)[0]) { ::String }, ::DatawireQuarkCore.cast((args)[1]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9241,15 +9241,15 @@ class ClassesStuffTestFooMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.foo((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.stuff.Test }
+        return obj.foo(::DatawireQuarkCore.cast((args)[0]) { ::Quark.classes.stuff.Test })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9295,7 +9295,7 @@ class ClassesStuffTestTestMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.classes.stuff.Test }
         obj.test()
         return nil
 
@@ -9304,7 +9304,7 @@ class ClassesStuffTestTestMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9364,7 +9364,7 @@ class ClassesStuffTest < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9412,8 +9412,8 @@ class StaticsFooSetCountMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        ::Quark.statics.Foo.setCount((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.statics.Foo }
+        ::Quark.statics.Foo.setCount(::DatawireQuarkCore.cast((args)[0]) { ::Integer })
         return nil
 
         nil
@@ -9421,7 +9421,7 @@ class StaticsFooSetCountMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9467,7 +9467,7 @@ class StaticsFooGetCountMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.statics.Foo }
         return ::Quark.statics.Foo.getCount()
 
         nil
@@ -9475,7 +9475,7 @@ class StaticsFooGetCountMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9521,7 +9521,7 @@ class StaticsFooTest1Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.statics.Foo }
         obj.test1()
         return nil
 
@@ -9530,7 +9530,7 @@ class StaticsFooTest1Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9576,7 +9576,7 @@ class StaticsFooTest2Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.statics.Foo }
         obj.test2()
         return nil
 
@@ -9585,7 +9585,7 @@ class StaticsFooTest2Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9631,7 +9631,7 @@ class StaticsFooTest3Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.statics.Foo }
         obj.test3()
         return nil
 
@@ -9640,7 +9640,7 @@ class StaticsFooTest3Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9686,7 +9686,7 @@ class StaticsFooTest4Method < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.statics.Foo }
         obj.test4()
         return nil
 
@@ -9695,7 +9695,7 @@ class StaticsFooTest4Method < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9755,7 +9755,7 @@ class StaticsFoo < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9803,15 +9803,15 @@ class DocsTestTestMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.test((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.docs.Test }
+        return obj.test(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9871,7 +9871,7 @@ class DocsTest < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9933,7 +9933,7 @@ class QuarkListQuarkListQuarkObject < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -9995,7 +9995,7 @@ class QuarkListQuarkObject < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -10057,7 +10057,7 @@ class QuarkListQuarkString < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -10175,7 +10175,7 @@ class Root < ::DatawireQuarkCore::QuarkObject
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end

--- a/quarkc/test/ffi/expected/rb/signatures/lib/statics.rb
+++ b/quarkc/test/ffi/expected/rb/signatures/lib/statics.rb
@@ -87,7 +87,7 @@ class Foo < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("count"))
-            ::Quark.statics.Foo.count = value
+            ::Quark.statics.Foo.count = ::DatawireQuarkCore.cast(value) { ::Integer }
         end
 
         nil

--- a/quarkc/test/ffi/expected/rb/slackpack/lib/slack.rb
+++ b/quarkc/test/ffi/expected/rb/slackpack/lib/slack.rb
@@ -105,10 +105,10 @@ class User < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("client"))
-            (self).client = value
+            (self).client = ::DatawireQuarkCore.cast(value) { ::Quark.slack.Client }
         end
         if ((name) == ("user"))
-            (self).user = value
+            (self).user = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -175,10 +175,10 @@ class Channel < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("client"))
-            (self).client = value
+            (self).client = ::DatawireQuarkCore.cast(value) { ::Quark.slack.Client }
         end
         if ((name) == ("channel"))
-            (self).channel = value
+            (self).channel = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -267,7 +267,7 @@ class Client < ::DatawireQuarkCore::QuarkObject
 
     def construct(type)
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::Quark.slack.event.SlackEvent }
 
         nil
     end
@@ -318,19 +318,19 @@ class Client < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("runtime"))
-            (self).runtime = value
+            (self).runtime = ::DatawireQuarkCore.cast(value) { ::Quark.quark.Runtime }
         end
         if ((name) == ("token"))
-            (self).token = value
+            (self).token = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("handler"))
-            (self).handler = value
+            (self).handler = ::DatawireQuarkCore.cast(value) { ::Quark.slack.SlackHandler }
         end
         if ((name) == ("event_id"))
-            (self).event_id = value
+            (self).event_id = ::DatawireQuarkCore.cast(value) { ::Integer }
         end
         if ((name) == ("socket"))
-            (self).socket = value
+            (self).socket = ::DatawireQuarkCore.cast(value) { ::Quark.quark.WebSocket }
         end
 
         nil

--- a/quarkc/test/ffi/expected/rb/slackpack/lib/slack/event.rb
+++ b/quarkc/test/ffi/expected/rb/slackpack/lib/slack/event.rb
@@ -70,16 +70,16 @@ class SlackEvent < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("type"))
-            (self).type = value
+            (self).type = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("user"))
-            (self).user = value
+            (self).user = ::DatawireQuarkCore.cast(value) { ::Quark.slack.User }
         end
         if ((name) == ("channel"))
-            (self).channel = value
+            (self).channel = ::DatawireQuarkCore.cast(value) { ::Quark.slack.Channel }
         end
         if ((name) == ("timestamp"))
-            (self).timestamp = value
+            (self).timestamp = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -167,22 +167,22 @@ class SlackError < ::Quark.slack.event.SlackEvent
     def _setField(name, value)
         
         if ((name) == ("type"))
-            (self).type = value
+            (self).type = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("user"))
-            (self).user = value
+            (self).user = ::DatawireQuarkCore.cast(value) { ::Quark.slack.User }
         end
         if ((name) == ("channel"))
-            (self).channel = value
+            (self).channel = ::DatawireQuarkCore.cast(value) { ::Quark.slack.Channel }
         end
         if ((name) == ("timestamp"))
-            (self).timestamp = value
+            (self).timestamp = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("code"))
-            (self).code = value
+            (self).code = ::DatawireQuarkCore.cast(value) { ::Integer }
         end
         if ((name) == ("text"))
-            (self).text = value
+            (self).text = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -255,16 +255,16 @@ class Hello < ::Quark.slack.event.SlackEvent
     def _setField(name, value)
         
         if ((name) == ("type"))
-            (self).type = value
+            (self).type = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("user"))
-            (self).user = value
+            (self).user = ::DatawireQuarkCore.cast(value) { ::Quark.slack.User }
         end
         if ((name) == ("channel"))
-            (self).channel = value
+            (self).channel = ::DatawireQuarkCore.cast(value) { ::Quark.slack.Channel }
         end
         if ((name) == ("timestamp"))
-            (self).timestamp = value
+            (self).timestamp = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil
@@ -355,28 +355,28 @@ class Message < ::Quark.slack.event.SlackEvent
     def _setField(name, value)
         
         if ((name) == ("type"))
-            (self).type = value
+            (self).type = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("user"))
-            (self).user = value
+            (self).user = ::DatawireQuarkCore.cast(value) { ::Quark.slack.User }
         end
         if ((name) == ("channel"))
-            (self).channel = value
+            (self).channel = ::DatawireQuarkCore.cast(value) { ::Quark.slack.Channel }
         end
         if ((name) == ("timestamp"))
-            (self).timestamp = value
+            (self).timestamp = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("subtype"))
-            (self).subtype = value
+            (self).subtype = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("hidden"))
-            (self).hidden = value
+            (self).hidden = ::DatawireQuarkCore.cast(value) { ::Object }
         end
         if ((name) == ("text"))
-            (self).text = value
+            (self).text = ::DatawireQuarkCore.cast(value) { ::String }
         end
         if ((name) == ("edited"))
-            (self).edited = value
+            (self).edited = ::DatawireQuarkCore.cast(value) { ::Quark.slack.event.Edited }
         end
 
         nil
@@ -438,10 +438,10 @@ class Edited < ::DatawireQuarkCore::QuarkObject
     def _setField(name, value)
         
         if ((name) == ("user"))
-            (self).user = value
+            (self).user = ::DatawireQuarkCore.cast(value) { ::Quark.slack.User }
         end
         if ((name) == ("timestamp"))
-            (self).timestamp = value
+            (self).timestamp = ::DatawireQuarkCore.cast(value) { ::String }
         end
 
         nil

--- a/quarkc/test/ffi/expected/rb/slackpack/lib/slackpack_md.rb
+++ b/quarkc/test/ffi/expected/rb/slackpack/lib/slackpack_md.rb
@@ -25,8 +25,8 @@ class SlackEventSlackEventLoadMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.load((args)[0], (args)[1])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.event.SlackEvent }
+        obj.load(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.Client }, ::DatawireQuarkCore.cast((args)[1]) { ::DatawireQuarkCore::JSONObject })
         return nil
 
         nil
@@ -34,7 +34,7 @@ class SlackEventSlackEventLoadMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -80,8 +80,8 @@ class SlackEventSlackEventDispatchMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.dispatch((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.event.SlackEvent }
+        obj.dispatch(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.SlackHandler })
         return nil
 
         nil
@@ -89,7 +89,7 @@ class SlackEventSlackEventDispatchMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -149,7 +149,7 @@ class SlackEventSlackEvent < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -197,8 +197,8 @@ class SlackEventSlackErrorLoadMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.load((args)[0], (args)[1])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.event.SlackError }
+        obj.load(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.Client }, ::DatawireQuarkCore.cast((args)[1]) { ::DatawireQuarkCore::JSONObject })
         return nil
 
         nil
@@ -206,7 +206,7 @@ class SlackEventSlackErrorLoadMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -252,8 +252,8 @@ class SlackEventSlackErrorDispatchMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.dispatch((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.event.SlackError }
+        obj.dispatch(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.SlackHandler })
         return nil
 
         nil
@@ -261,7 +261,7 @@ class SlackEventSlackErrorDispatchMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -321,7 +321,7 @@ class SlackEventSlackError < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -369,8 +369,8 @@ class SlackEventHelloDispatchMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.dispatch((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.event.Hello }
+        obj.dispatch(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.SlackHandler })
         return nil
 
         nil
@@ -378,7 +378,7 @@ class SlackEventHelloDispatchMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -424,8 +424,8 @@ class SlackEventHelloLoadMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.load((args)[0], (args)[1])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.event.Hello }
+        obj.load(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.Client }, ::DatawireQuarkCore.cast((args)[1]) { ::DatawireQuarkCore::JSONObject })
         return nil
 
         nil
@@ -433,7 +433,7 @@ class SlackEventHelloLoadMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -493,7 +493,7 @@ class SlackEventHello < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -541,8 +541,8 @@ class SlackEventMessageLoadMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.load((args)[0], (args)[1])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.event.Message }
+        obj.load(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.Client }, ::DatawireQuarkCore.cast((args)[1]) { ::DatawireQuarkCore::JSONObject })
         return nil
 
         nil
@@ -550,7 +550,7 @@ class SlackEventMessageLoadMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -596,8 +596,8 @@ class SlackEventMessageDispatchMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.dispatch((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.event.Message }
+        obj.dispatch(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.SlackHandler })
         return nil
 
         nil
@@ -605,7 +605,7 @@ class SlackEventMessageDispatchMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -665,7 +665,7 @@ class SlackEventMessage < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -727,7 +727,7 @@ class SlackEventEdited < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -775,8 +775,8 @@ class SlackSlackHandlerOnSlackEventMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onSlackEvent((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.SlackHandler }
+        obj.onSlackEvent(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.event.SlackEvent })
         return nil
 
         nil
@@ -784,7 +784,7 @@ class SlackSlackHandlerOnSlackEventMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -830,8 +830,8 @@ class SlackSlackHandlerOnHelloMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onHello((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.SlackHandler }
+        obj.onHello(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.event.Hello })
         return nil
 
         nil
@@ -839,7 +839,7 @@ class SlackSlackHandlerOnHelloMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -885,8 +885,8 @@ class SlackSlackHandlerOnSlackErrorMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onSlackError((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.SlackHandler }
+        obj.onSlackError(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.event.SlackError })
         return nil
 
         nil
@@ -894,7 +894,7 @@ class SlackSlackHandlerOnSlackErrorMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -940,8 +940,8 @@ class SlackSlackHandlerOnMessageMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onMessage((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.SlackHandler }
+        obj.onMessage(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.event.Message })
         return nil
 
         nil
@@ -949,7 +949,7 @@ class SlackSlackHandlerOnMessageMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1009,7 +1009,7 @@ class SlackSlackHandler < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1064,14 +1064,14 @@ class SlackUser < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.slack.User.new((args)[0], (args)[1])
+        return ::Quark.slack.User.new(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.Client }, ::DatawireQuarkCore.cast((args)[1]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1119,8 +1119,8 @@ class SlackChannelSendMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.send((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Channel }
+        obj.send(::DatawireQuarkCore.cast((args)[0]) { ::String })
         return nil
 
         nil
@@ -1128,7 +1128,7 @@ class SlackChannelSendMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1181,14 +1181,14 @@ class SlackChannel < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.slack.Channel.new((args)[0], (args)[1])
+        return ::Quark.slack.Channel.new(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.Client }, ::DatawireQuarkCore.cast((args)[1]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1236,7 +1236,7 @@ class SlackClientConnectMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
         obj.connect()
         return nil
 
@@ -1245,7 +1245,7 @@ class SlackClientConnectMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1291,8 +1291,8 @@ class SlackClientRequestMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.request((args)[0], (args)[1], (args)[2])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.request(::DatawireQuarkCore.cast((args)[0]) { ::String }, ::DatawireQuarkCore.cast((args)[1]) { ::Hash }, ::DatawireQuarkCore.cast((args)[2]) { ::Quark.quark.HTTPHandler })
         return nil
 
         nil
@@ -1300,7 +1300,7 @@ class SlackClientRequestMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1346,8 +1346,8 @@ class SlackClientWsConnectMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.ws_connect((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.ws_connect(::DatawireQuarkCore.cast((args)[0]) { ::String })
         return nil
 
         nil
@@ -1355,7 +1355,7 @@ class SlackClientWsConnectMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1401,8 +1401,8 @@ class SlackClientWsSendMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.ws_send((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.ws_send(::DatawireQuarkCore.cast((args)[0]) { ::String })
         return nil
 
         nil
@@ -1410,7 +1410,7 @@ class SlackClientWsSendMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1456,8 +1456,8 @@ class SlackClientOnWSConnectedMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onWSConnected((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.onWSConnected(::DatawireQuarkCore.cast((args)[0]) { ::Quark.quark.WebSocket })
         return nil
 
         nil
@@ -1465,7 +1465,7 @@ class SlackClientOnWSConnectedMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1511,8 +1511,8 @@ class SlackClientOnWSCloseMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onWSClose((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.onWSClose(::DatawireQuarkCore.cast((args)[0]) { ::Quark.quark.WebSocket })
         return nil
 
         nil
@@ -1520,7 +1520,7 @@ class SlackClientOnWSCloseMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1566,8 +1566,8 @@ class SlackClientOnWSErrorMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onWSError((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.onWSError(::DatawireQuarkCore.cast((args)[0]) { ::Quark.quark.WebSocket })
         return nil
 
         nil
@@ -1575,7 +1575,7 @@ class SlackClientOnWSErrorMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1621,15 +1621,15 @@ class SlackClientConstructMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        return obj.construct((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        return obj.construct(::DatawireQuarkCore.cast((args)[0]) { ::String })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1675,8 +1675,8 @@ class SlackClientOnWSMessageMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onWSMessage((args)[0], (args)[1])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.onWSMessage(::DatawireQuarkCore.cast((args)[0]) { ::Quark.quark.WebSocket }, ::DatawireQuarkCore.cast((args)[1]) { ::String })
         return nil
 
         nil
@@ -1684,7 +1684,7 @@ class SlackClientOnWSMessageMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1730,8 +1730,8 @@ class SlackClientOnHTTPResponseMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onHTTPResponse((args)[0], (args)[1])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.onHTTPResponse(::DatawireQuarkCore.cast((args)[0]) { ::Quark.quark.HTTPRequest }, ::DatawireQuarkCore.cast((args)[1]) { ::Quark.quark.HTTPResponse })
         return nil
 
         nil
@@ -1739,7 +1739,7 @@ class SlackClientOnHTTPResponseMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1785,8 +1785,8 @@ class SlackClientOnWSInitMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onWSInit((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.onWSInit(::DatawireQuarkCore.cast((args)[0]) { ::Quark.quark.WebSocket })
         return nil
 
         nil
@@ -1794,7 +1794,7 @@ class SlackClientOnWSInitMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1840,8 +1840,8 @@ class SlackClientOnWSBinaryMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onWSBinary((args)[0], (args)[1])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.onWSBinary(::DatawireQuarkCore.cast((args)[0]) { ::Quark.quark.WebSocket }, (args)[1])
         return nil
 
         nil
@@ -1849,7 +1849,7 @@ class SlackClientOnWSBinaryMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1895,8 +1895,8 @@ class SlackClientOnWSClosedMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onWSClosed((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.onWSClosed(::DatawireQuarkCore.cast((args)[0]) { ::Quark.quark.WebSocket })
         return nil
 
         nil
@@ -1904,7 +1904,7 @@ class SlackClientOnWSClosedMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -1950,8 +1950,8 @@ class SlackClientOnWSFinalMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onWSFinal((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.onWSFinal(::DatawireQuarkCore.cast((args)[0]) { ::Quark.quark.WebSocket })
         return nil
 
         nil
@@ -1959,7 +1959,7 @@ class SlackClientOnWSFinalMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2005,8 +2005,8 @@ class SlackClientOnHTTPInitMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onHTTPInit((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.onHTTPInit(::DatawireQuarkCore.cast((args)[0]) { ::Quark.quark.HTTPRequest })
         return nil
 
         nil
@@ -2014,7 +2014,7 @@ class SlackClientOnHTTPInitMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2060,8 +2060,8 @@ class SlackClientOnHTTPErrorMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onHTTPError((args)[0], (args)[1])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.onHTTPError(::DatawireQuarkCore.cast((args)[0]) { ::Quark.quark.HTTPRequest }, ::DatawireQuarkCore.cast((args)[1]) { ::String })
         return nil
 
         nil
@@ -2069,7 +2069,7 @@ class SlackClientOnHTTPErrorMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2115,8 +2115,8 @@ class SlackClientOnHTTPFinalMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onHTTPFinal((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slack.Client }
+        obj.onHTTPFinal(::DatawireQuarkCore.cast((args)[0]) { ::Quark.quark.HTTPRequest })
         return nil
 
         nil
@@ -2124,7 +2124,7 @@ class SlackClientOnHTTPFinalMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2177,14 +2177,14 @@ class SlackClient < ::Quark.quark.reflect.QuarkClass
 
     def construct(args)
         
-        return ::Quark.slack.Client.new((args)[0], (args)[1], (args)[2])
+        return ::Quark.slack.Client.new(::DatawireQuarkCore.cast((args)[0]) { ::Quark.quark.Runtime }, ::DatawireQuarkCore.cast((args)[1]) { ::String }, ::DatawireQuarkCore.cast((args)[2]) { ::Quark.slack.SlackHandler })
 
         nil
     end
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2232,8 +2232,8 @@ class SlackpackHandlerOnSlackEventMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onSlackEvent((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slackpack.Handler }
+        obj.onSlackEvent(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.event.SlackEvent })
         return nil
 
         nil
@@ -2241,7 +2241,7 @@ class SlackpackHandlerOnSlackEventMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2287,8 +2287,8 @@ class SlackpackHandlerOnHelloMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onHello((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slackpack.Handler }
+        obj.onHello(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.event.Hello })
         return nil
 
         nil
@@ -2296,7 +2296,7 @@ class SlackpackHandlerOnHelloMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2342,8 +2342,8 @@ class SlackpackHandlerOnSlackErrorMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onSlackError((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slackpack.Handler }
+        obj.onSlackError(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.event.SlackError })
         return nil
 
         nil
@@ -2351,7 +2351,7 @@ class SlackpackHandlerOnSlackErrorMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2397,8 +2397,8 @@ class SlackpackHandlerOnMessageMethod < ::Quark.quark.reflect.Method
 
     def invoke(object, args)
         
-        obj = object
-        obj.onMessage((args)[0])
+        obj = ::DatawireQuarkCore.cast(object) { ::Quark.slackpack.Handler }
+        obj.onMessage(::DatawireQuarkCore.cast((args)[0]) { ::Quark.slack.event.Message })
         return nil
 
         nil
@@ -2406,7 +2406,7 @@ class SlackpackHandlerOnMessageMethod < ::Quark.quark.reflect.Method
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2466,7 +2466,7 @@ class SlackpackHandler < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2528,7 +2528,7 @@ class QuarkMapQuarkStringQuarkObject < ::Quark.quark.reflect.QuarkClass
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end
@@ -2588,7 +2588,7 @@ class Root < ::DatawireQuarkCore::QuarkObject
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end

--- a/quarkc/test/ffi/expected/rb/test/lib/testlib.rb
+++ b/quarkc/test/ffi/expected/rb/test/lib/testlib.rb
@@ -5,7 +5,7 @@ module Testlib
 
 def self.atest()
     
-    return nil
+    return ::DatawireQuarkCore.cast(nil) { ::String }
 
 
     nil
@@ -13,7 +13,7 @@ end
 
 def self.foo()
     
-    return nil
+    return ::DatawireQuarkCore.cast(nil) { ::String }
 
 
     nil

--- a/quarkc/test/ffi/expected/rb/test/lib/testlib_md.rb
+++ b/quarkc/test/ffi/expected/rb/test/lib/testlib_md.rb
@@ -18,7 +18,7 @@ class Root < ::DatawireQuarkCore::QuarkObject
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end

--- a/quarkc/test/ffi/expected/rb/use/lib/puse_md.rb
+++ b/quarkc/test/ffi/expected/rb/use/lib/puse_md.rb
@@ -18,7 +18,7 @@ class Root < ::DatawireQuarkCore::QuarkObject
 
     def _getClass()
         
-        return nil
+        return ::DatawireQuarkCore.cast(nil) { ::String }
 
         nil
     end


### PR DESCRIPTION
- [x] Ruby
- [x] Python
- [x] JavaScript 

From change log:

### Foreign-function interface

* (!) Change how cast operator (`?`) works on dynamically-typed back-ends
  (Python, Ruby, JavaScript). Previously casting on dynamically-typed back-ends
  had no effect, now it is translated into an assertion that the value is
  of that type which it is being cast into. The effect on FFI is that now,
  you are required to subclass classes/interfaces if you implement them,
  instead of relying on duck-typing.
* Calling abstract/interface methods produces a readable error message,
  instead of a simple assertion failure.
