### PR TITLE
Disable runtime casting checks on Python, Javascript and Ruby

### DIFF
--- a/quarkc/lib/datawire-quark-core.rb
+++ b/quarkc/lib/datawire-quark-core.rb
@@ -1045,6 +1045,8 @@ module DatawireQuarkCore
   def self.cast(value, &block)
     # For now there is no easy way to check in Ruby that Quark class C is
     # subclass of of Quark class B, so don't check anything until that's fixed.
+    # The correct way to do so would be via reflect.Class.hasInstance, probably,
+    # but that doesn't support interfaces yet.
     value
   end
 

--- a/quarkc/lib/datawire-quark-core.rb
+++ b/quarkc/lib/datawire-quark-core.rb
@@ -1043,12 +1043,8 @@ module DatawireQuarkCore
   end
 
   def self.cast(value, &block)
-    type = begin block.call rescue Object end
-
-    unless value.is_a?(type) || value.nil?
-      raise TypeError, "`#{value.inspect}` is not an instance of `#{type}`"
-    end
-
+    # For now there is no easy way to check in Ruby that Quark class C is
+    # subclass of of Quark class B, so don't check anything until that's fixed.
     value
   end
 

--- a/quarkc/lib/quark_runtime.js
+++ b/quarkc/lib/quark_runtime.js
@@ -75,7 +75,9 @@
     function cast(value, callback) {
         // For now there is no easy way to check in Javascript that Quark class
         // C is subclass of of Quark class B, so don't check anything until
-        // that's fixed.
+        // that's fixed. The correct way to do so would be via
+        // reflect.Class.hasInstance, probably, but that doesn't support
+        // interfaces yet.
         return value;
     }
     exports.cast = cast;

--- a/quarkc/lib/quark_runtime.js
+++ b/quarkc/lib/quark_runtime.js
@@ -73,20 +73,10 @@
     }
 
     function cast(value, callback) {
-        try {
-            var type = callback();
-            if (value == null || is_instance_of(value, type)) {
-                return value;
-            } else {
-                throw TypeError,
-                    '`' + value + '` is not an instance of `' + type + '`';
-            }
-        } catch (error) {
-            if (error instanceof ReferenceError) {
-                return value;
-            }
-            throw error;
-        }
+        // For now there is no easy way to check in Javascript that Quark class
+        // C is subclass of of Quark class B, so don't check anything until
+        // that's fixed.
+        return value;
     }
     exports.cast = cast;
 

--- a/quarkc/lib/quark_runtime.py
+++ b/quarkc/lib/quark_runtime.py
@@ -63,8 +63,10 @@ def _map_remove(m, key):
         return None
 
 def _cast(value, callback):
-    # For now there is no easy way to check in Python that Quark class C is
-    # subclass of of Quark class B, so don't check anything until that's fixed.
+    # For now  there is no  easy way to  check in Python  that Quark class  C is
+    # subclass of of Quark class B,  so don't check anything until that's fixed.
+    # The correct way to do so would be via reflect.Class.hasInstance, probably,
+    # but that doesn't support interfaces yet.
     return value
 
 class _JSONObject(object):

--- a/quarkc/lib/quark_runtime.py
+++ b/quarkc/lib/quark_runtime.py
@@ -63,17 +63,9 @@ def _map_remove(m, key):
         return None
 
 def _cast(value, callback):
-    try:
-        type = callback()
-    except:
-        type = object
-    if type is unicode:
-        type = (unicode, str)
-    if isinstance(value, type) or value is None:
-        return value
-    else:
-        template = '`{value}` is not an instance of `{type}`'.format
-        raise TypeError(template(value=repr(value), type=type))
+    # For now there is no easy way to check in Python that Quark class C is
+    # subclass of of Quark class B, so don't check anything until that's fixed.
+    return value
 
 class _JSONObject(object):
     _backend = json

--- a/quarkc/test/lib/casting_test.q
+++ b/quarkc/test/lib/casting_test.q
@@ -53,7 +53,6 @@ class CastingTest {
         local.C asSuperFromObject = ?asObject;
         checkEqual(d, asSuperFromObject);
     }
-
 }
 
 void main(List<String> args) {

--- a/quarkc/test/lib/casting_test.q
+++ b/quarkc/test/lib/casting_test.q
@@ -1,0 +1,61 @@
+quark *;
+
+import quark.test;
+
+namespace local {
+    interface I {
+        void f();
+    }
+
+    class C extends I {
+        void f() {}
+    }
+
+    class D extends C {
+    }
+}
+
+class CastingTest {
+    // An instance can be cast to its class
+    void testCastingToClass() {
+        local.C c = new local.C();
+        local.C c2 = ?c;
+        checkEqual(c, c2);
+    }
+
+    // An instance can be cast to an interface implemented by the class
+    void testCastingToInterface() {
+        local.C c = new local.C();
+        local.I asInterface = ?c;
+        checkEqual(c, asInterface);
+    }
+
+    // An instance can be cast to an interface implemented by the class, via
+    // casting to Object
+    void testCastingToInterfaceViaObject() {
+        local.C c = new local.C();
+        Object asObject = ?c;
+        local.I asInterfaceFromObject = ?asObject;
+        checkEqual(c, asInterfaceFromObject);
+    }
+
+    // An instance can be cast to a superclass
+    void testCastingToSuperclass() {
+        local.D d = new local.D();
+        local.C asSuper = ?d;
+        checkEqual(d, asSuper);
+    }
+
+    // An instance can be cast to a superclass, via casting to Object
+    void testCastingToSuperclassViaObject() {
+        local.D d = new local.D();
+        Object asObject = ?d;
+        local.C asSuperFromObject = ?asObject;
+        checkEqual(d, asSuperFromObject);
+    }
+
+}
+
+void main(List<String> args) {
+    test.run(args);
+}

--- a/quarkc/test/lib/reflect_test.q
+++ b/quarkc/test/lib/reflect_test.q
@@ -158,4 +158,8 @@ class ClassReflectTest {
         checkEqual(false, aClass.hasInstance(new Lock()));
         checkEqual(false, aClass.hasInstance(new Condition()));
     }
+
+    // TODO: hasInstance currently doesn't support interfaces or parameterized
+    // types, e.g. List<K> or YourClass<K,V>. We should add that and then write
+    // tests.
 }


### PR DESCRIPTION
They don't actually check what they claim they check, and this is blocking me. For now we'll have to rely on Java tests; eventually we should do this right.