### PR TITLE
Add uuid() and make now/sleep/uuid delegate to Runtime methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,14 @@ Latest
 * Added `String.ordAt`
 * Added `String.strip`
 * Added `String.parseInt` and `String.parseLong`
+
 * Returning `undefined` from a Javascript function used as a `Promise` callback
   no longer blows up.
+
+* Added `quark.uuid`, which calls `Runtime.uuid`, to generate a UUID v4 string.
+
+* Changed `quark.sleep` and `quark.now` to delegate to methods on `Runtime` so
+  that they can be replaced with mock versions.
 
 1.0.282
 ------

--- a/quarkc/lib/datawire-quark-core.rb
+++ b/quarkc/lib/datawire-quark-core.rb
@@ -9,6 +9,7 @@ module DatawireQuarkCore
   require 'reel'
   require 'logging'
   require 'event_emitter'
+  require 'securerandom'
 
   module GettersSetters
     # Generate Java/Quark-style getters and setters for
@@ -138,10 +139,6 @@ module DatawireQuarkCore
     result = result + [''] if string.end_with? separator
 
     result
-  end
-
-  def self.now
-    (Time.now.to_f * 1000).round
   end
 
   def self.getFileContents(path, result)
@@ -700,6 +697,18 @@ module DatawireQuarkCore
 
     def codec
       return Codec.new
+    end
+
+    def now
+      (Time.now.to_f * 1000).round
+    end
+
+    def sleep(seconds)
+      Kernel.sleep seconds
+    end
+
+    def uuid
+      SecureRandom.uuid
     end
   end
 

--- a/quarkc/lib/io/datawire/quark/netty/QuarkNettyRuntime.java
+++ b/quarkc/lib/io/datawire/quark/netty/QuarkNettyRuntime.java
@@ -423,6 +423,25 @@ public class QuarkNettyRuntime extends AbstractDatawireRuntime implements Runtim
         return Builtins.defaultCodec();
     }
 
+    @Override
+    public Long now() {
+        return System.currentTimeMillis();
+    }
+
+    @Override
+    public void sleep(Double seconds) {
+        try {
+            Thread.sleep((int)(seconds * 1000));
+        } catch(InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public String uuid() {
+        return java.util.UUID.randomUUID().toString();
+    }
+
     public static ByteBuf adaptBuffer(Buffer quarkBuffer) {
         // TODO: add netty implementation of runtime buffer and short-circuit here
         if (quarkBuffer instanceof BufferImpl) {

--- a/quarkc/lib/io/datawire/quark/runtime/Builtins.java
+++ b/quarkc/lib/io/datawire/quark/runtime/Builtins.java
@@ -54,14 +54,6 @@ public class Builtins {
         }
     }
 
-    public static void sleep(double seconds) {
-        try {
-            Thread.sleep((int)(seconds * 1000));
-        } catch(InterruptedException ex) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
     @SuppressWarnings("rawtypes")
     public static String urlencode(Map map) {
         QueryStringEncoder enc = new QueryStringEncoder("");

--- a/quarkc/lib/mock.q
+++ b/quarkc/lib/mock.q
@@ -315,6 +315,18 @@ class MockRuntime extends Runtime {
         return runtime.codec();
     }
 
+    long now() {
+        return runtime.now();
+    }
+
+    void sleep(float seconds) {
+        runtime.sleep(seconds);
+    }
+
+    String uuid() {
+        return runtime.uuid();
+    }
+
     void serveHTTP(String url, HTTPServlet servlet) {
         runtime.fail("Runtime.serveHTTP not yet supported by the MockRuntime");
     }

--- a/quarkc/lib/quark.q
+++ b/quarkc/lib/quark.q
@@ -53,16 +53,6 @@ macro void print(Object msg) $java{do{System.out.println($msg);System.out.flush(
                              $rb{::DatawireQuarkCore.print($msg)}
                              $js{_qrt.print($msg)};
 
-macro long now() $java{System.currentTimeMillis()}
-                 $py{long(time.time()*1000)}
-                 $rb{::DatawireQuarkCore.now}
-                 $js{Date.now()};
-
-macro void sleep(float seconds) $java{io.datawire.quark.runtime.Builtins.sleep($seconds)}
-                                $py{time.sleep($seconds)}
-                                $rb{sleep($seconds)}
-                                $js{_qrt.sleep($seconds)};
-
 macro String url_get(String url) $java{io.datawire.quark.runtime.Builtins.url_get($url)}
                                  $py{_url_get($url)}
                                  $rb{::DatawireQuarkCore.url_get($url)}
@@ -79,7 +69,9 @@ macro Codec defaultCodec() $java{io.datawire.quark.runtime.Builtins.defaultCodec
                            $js{_qrt.defaultCodec()};
 
 macro void _trace() $java{do{new Throwable().printStackTrace();} while(false)}
-                    $py{__import__("traceback").print_stack()};
+                    $py{__import__("traceback").print_stack()}
+                    $js{console.trace()}
+                    $rb{puts caller};
 
 macro void panic(String msg) $java{throw new RuntimeException($msg)}
                              $py{raise Exception($msg)}
@@ -108,4 +100,22 @@ interface Runtime {
 
     @doc("Get a logger for the specified topic.")
     Logger logger(String topic);
+
+    @doc("Get epoch time in milliseconds")
+    long now();
+
+    @doc("Suspend execution of this thread for some number of seconds")
+    void sleep(float seconds);
+
+    @doc("Get a v4 random UUID (Universally Unique IDentifier)")
+    String uuid();
 }
+
+@doc("Get epoch time in milliseconds")
+long now() { return quark.concurrent.Context.runtime().now(); }
+
+@doc("Suspend execution of this thread for some number of seconds")
+void sleep(float seconds) { quark.concurrent.Context.runtime().sleep(seconds); }
+
+@doc("Get a v4 random UUID (Universally Unique IDentifier)")
+String uuid() { return quark.concurrent.Context.runtime().uuid(); }

--- a/quarkc/lib/quark_node_runtime.js
+++ b/quarkc/lib/quark_node_runtime.js
@@ -451,6 +451,15 @@
 
     Runtime.prototype.codec = function() { return runtime.defaultCodec(); };
 
+    Runtime.prototype.now = function() { return Date.now(); };
+
+    var execSync = require("child_process").execSync;
+    Runtime.prototype.sleep = function (seconds) { execSync("sleep " + seconds); };
+
+    Runtime.prototype.uuid = function() {
+        // https://gist.github.com/jed/982883
+        return (function b(a){return a?(a^Math.random()*16>>a/4).toString(16):([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g,b);})();  // jshint ignore: line
+    };
 
     function QuarkContainer() {
         this.servlets = {};

--- a/quarkc/lib/quark_runtime.js
+++ b/quarkc/lib/quark_runtime.js
@@ -157,11 +157,6 @@
     }
     exports.urlencode = urlencode;
 
-    function sleep(seconds) {
-        execSync("sleep " + seconds);
-    }
-    exports.sleep = sleep;
-
     function JSONObject() {
         this.value = null;
     }

--- a/quarkc/lib/quark_threaded_runtime.py
+++ b/quarkc/lib/quark_threaded_runtime.py
@@ -11,6 +11,7 @@ import time
 import traceback
 import urllib2
 import urlparse
+import uuid
 from wsgiref import util
 from Queue import Queue, Empty
 import quark
@@ -515,6 +516,15 @@ class ThreadedRuntime(object):
 
     def logger(self, topic):
         return Logger(topic)
+
+    def now(self):
+        return long(time.time() * 1000)
+
+    def sleep(self, seconds):
+        time.sleep(seconds)
+
+    def uuid(self):
+        return str(uuid.uuid4())
 
 _global_lock = threading.Lock()
 _threaded_runtime = None

--- a/quarkc/lib/spi_api.q
+++ b/quarkc/lib/spi_api.q
@@ -71,6 +71,15 @@ namespace spi_api {
         Codec codec() {
             return impl.codec();
         }
+        long now() {
+            return impl.now();
+        }
+        void sleep(float seconds) {
+            impl.sleep(seconds);
+        }
+        String uuid() {
+            return impl.uuid();
+        }
         void serveHTTP(String url, HTTPServlet servlet) {
             impl.serveHTTP(url, new HTTPServletProxy(self, servlet));
         }

--- a/quarkc/lib/spi_api_tracing.q
+++ b/quarkc/lib/spi_api_tracing.q
@@ -342,6 +342,20 @@ namespace spi_api_tracing {
             self.log.debug(self.id + ".codec()");
             return impl.codec();
         }
+        long now() {
+            self.log.debug(self.id + ".now()");
+            return impl.now();
+        }
+        void sleep(float seconds) {
+            self.log.debug(self.id + ".sleep("
+                           + seconds.toString()
+                           + ")");
+            impl.sleep(seconds);
+        }
+        String uuid() {
+            self.log.debug(self.id + ".uuid()");
+            return impl.uuid();
+        }
         void serveHTTP(String url, HTTPServlet servlet) {
             HTTPServletProxy wrapped_servlet = new HTTPServletProxy(self.log, self, servlet);
             self.log.debug(self.id + ".serveHTTP("

--- a/quarkc/test/lib/concurrent_test.q
+++ b/quarkc/test/lib/concurrent_test.q
@@ -22,4 +22,13 @@ class ConcurrentTest {
         check(elapsed < 750, "Expected elapsed < 750 ms got " + elapsedStr);
         check(elapsed > 400, "Expected elapsed > 400 ms got " + elapsedStr);
     }
+
+    void testSleep() {
+        long start = now();
+        sleep(0.5);
+        long elapsed = now() - start;
+        String elapsedStr = elapsed.toString() + " ms";
+        check(elapsed < 750, "Expected elapsed < 750 ms got " + elapsedStr);
+        check(elapsed > 400, "Expected elapsed > 400 ms got " + elapsedStr);
+    }
 }

--- a/quarkc/test/lib/uuid_test.q
+++ b/quarkc/test/lib/uuid_test.q
@@ -1,0 +1,54 @@
+quark *;
+import quark.test;
+
+void main(List<String> args) {
+    test.run(args);
+}
+
+class UUIDTest {
+
+    int a = "a".ordAt(0);
+    int f = "f".ordAt(0);
+    int AA = "A".ordAt(0);
+    int FF = "F".ordAt(0);
+    int zero = "0".ordAt(0);
+    int nine = "9".ordAt(0);
+
+    bool isHex(String value, int index) {
+        // Assumes ASCII-ish encoding...
+        int ordVal = value.ordAt(index);
+        return (((a <= ordVal) && (ordVal <= f)) ||
+                ((AA <= ordVal) && (ordVal <= FF)) ||
+                ((zero <= ordVal) && (ordVal <= nine)));
+    }
+
+    void test_uuid() {
+        String res = uuid();
+        check(res != null, "Expected UUID is not null");
+        check(res.size() == 36, "Expected UUID to be 36 characters (" + res.size().toString() + ")");
+
+        int idx = 0;
+        while (idx < 36) {
+            if ((idx == 8) || (idx == 13) || (idx == 18) || (idx == 23)) {
+                check(res.ordAt(idx) == "-".ordAt(0),
+                      "Expected UUID[" + idx.toString() + "] to be '-' (" + res + ")");
+            } else {
+                if (idx == 14) {
+                    check(res.ordAt(idx) == "4".ordAt(0),
+                          "Expected UUID[" + idx.toString() + "] to be '4' (" + res + ")");
+                } else {
+                    if (idx == 19) {
+                        int ordVal = res.ordAt(idx);
+                        check((ordVal == nine - 1) || (ordVal == nine) ||
+                              (ordVal == AA) || (ordVal == a) ||
+                              (ordVal == AA + 1) || (ordVal == a + 1),
+                              "Expected UUID[" + idx.toString() + "] to be hex 8..b (" + res + ")");
+                    } else {
+                        check(isHex(res, idx), "Expected UUID[" + idx.toString() + "] to be hex (" + res + ")");
+                    }
+                }
+            }
+            idx = idx + 1;
+        }
+    }
+}

--- a/runtime/tests/test_interop.py
+++ b/runtime/tests/test_interop.py
@@ -58,7 +58,6 @@ class QuarkCompile(object):
         self.process_includes()
         print "Need to compile", self.processed
         self.quark("install",
-                   "--online",
                    "--java",
                    "--javascript",
                    "--python",

--- a/runtime/tests/test_interop.py
+++ b/runtime/tests/test_interop.py
@@ -58,6 +58,7 @@ class QuarkCompile(object):
         self.process_includes()
         print "Need to compile", self.processed
         self.quark("install",
+                   "--online",
                    "--java",
                    "--javascript",
                    "--python",


### PR DESCRIPTION
- Add quark.uuid, which delegates to Runtime.uuid
- Make quark.now and quark.sleep delegate to Runtime methods
- Mock runtime calls original versions but that can be changed