### PR TITLE
Rhs/logging tweak

### DIFF
--- a/quarkc/lib/logging.q
+++ b/quarkc/lib/logging.q
@@ -71,6 +71,10 @@ namespace quark {
                 return envVarValue;
             }
 
+            static bool _autoconfig() {
+                return !_configured && _getOverrideIfExists() != null;
+            }
+
             @doc("Configure the logging")
             void configure() {
                 String envVarValue = Config._getOverrideIfExists();
@@ -94,7 +98,7 @@ namespace quark {
     }
 
     Logger _getLogger(String topic) {
-        if (!quark.logging.Config._configured) {
+        if (quark.logging.Config._autoconfig()) {
             quark.logging.makeConfig().configure();
         }
         return quark.concurrent.Context.current().runtime().logger(topic);

--- a/quarkc/test/test_env_tracing.py
+++ b/quarkc/test/test_env_tracing.py
@@ -195,13 +195,15 @@ def test_env_tracing():
             print
             print language, "-- logging NOT configured", "==" * 20
 
-            print
-            print "Run no qtrace no ttrace", language
-            output = do_quark_run(quark_file_name, language, {}, unenv)
-            assert_user_info(output)
-            assert_not_quark_trace(output)
-            assert fetch_file(qtrace_file_name) is None
-            assert fetch_file(ttrace_file_name) is None
+            # XXX: I dont think we can test this case because default
+            # behavior is language dependent.
+            # print
+            # print "Run no qtrace no ttrace", language
+            # output = do_quark_run(quark_file_name, language, {}, unenv)
+            # assert_user_info(output)
+            # assert_not_quark_trace(output)
+            # assert fetch_file(qtrace_file_name) is None
+            # assert fetch_file(ttrace_file_name) is None
 
             print
             print "Run qtrace 1 no ttrace", language


### PR DESCRIPTION
The new default logging behavior was slightly to aggressive about configuring logging. It would autoconfigure logging for my interactive python buffer and the periodic messages that get logged would make it pretty much impossible to live code. ;-)

This PR tweaks the defaults so that we only autoconfigure logging if the QUARK_TRACE environment variable is present, otherwise we will fallback to the language's default behavior when logging is unconfigured.

The change is pretty trivial, but I had to comment out a chunk of the test that I *think* now depends on the default language semantics and therefore no longer makes sense to test, but I would like @ark3 to review and confirm my understanding of what the test is trying to do.