### PR TITLE
Test runner uses correct exit code

### DIFF
--- a/quarkc/lib/testing.q
+++ b/quarkc/lib/testing.q
@@ -201,7 +201,8 @@ class Harness {
         }
     }
 
-    void run() {
+    @doc("Run the tests, return number of failures.")
+    int run() {
         print(bold("=============================== starting tests ==============================="));
 
         int idx = 0;
@@ -229,6 +230,7 @@ class Harness {
         } else {
             print(green(result));
         }
+        return failures;
     }
 
     void json_report() {
@@ -280,9 +282,12 @@ void run(List<String> args) {
         h.list();
     } else {
         print(bold("Running: " + " ".join(args)));
-        h.run();
+        int failures = h.run();
         if (json) {
             h.json_report();
+        }
+        if (failures > 0) {
+            Context.runtime().fail("Test run failed.");
         }
     }
 }

--- a/quarkc/test/test_testing.py
+++ b/quarkc/test/test_testing.py
@@ -1,0 +1,42 @@
+# Copyright 2015 datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the Quark test runner that can't be accommodated some other way.
+"""
+
+import os
+from subprocess import Popen, check_call
+
+
+TESTING_FILE = os.path.join(os.path.dirname(__file__), "test_testing.q")
+
+
+def install_and_run(quark_file, test_name):
+    """Install and run a specific test in a quark file, return the exit code."""
+    check_call(["quark", "install", "--python", quark_file])
+    p = Popen(["quark", "run", "--python", quark_file, test_name])
+    return p.wait()
+
+
+def test_success():
+    """A successful test run by the Quark test runner has exit code 0."""
+    code = install_and_run(TESTING_FILE, "testSucceed")
+    assert code == 0
+
+
+def test_failure():
+    """A failed test run by the Quark test runner has exit code 1."""
+    code = install_and_run(TESTING_FILE, "testFail")
+    assert code == 1

--- a/quarkc/test/test_testing.q
+++ b/quarkc/test/test_testing.q
@@ -1,0 +1,20 @@
+quark *;
+
+/* Used by test_testing.py */
+
+import quark.test;
+
+
+class FailOrSucceedTest {
+    void testSucceed() {
+	return;
+    }
+
+    void testFail() {
+	check(false, "Fail the test, so the test runner has a non-0 exit code.");
+    }
+}
+
+void main(List<String> args) {
+    test.run(args);
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ twine
 sphinx-better-theme
 docopt
 sphinx
-flake8
+# flake8 decided to ignore setup.cfg. 3.0.3 may fix this, currently there's only 3.0.2.
+flake8<3.0.0
 pylint


### PR DESCRIPTION
This will allow use of quark tests in e.g. Makefiles or the like to work as expected, instead of silently failing.