### PR TITLE
Quark standard library now has a version number that is not 0.0.1

### DIFF
--- a/quarkc/lib/quark.q
+++ b/quarkc/lib/quark.q
@@ -26,7 +26,7 @@ use java junit junit 4.12;
 include io/datawire/quark/runtime/AbstractDatawireRuntime.java;
 include io/datawire/quark/runtime/Builtins.java;
 
-package quark 0.0.1;
+package quark 1.0.332;
 
 import quark.error;
 

--- a/quarkc/parser.py
+++ b/quarkc/parser.py
@@ -151,7 +151,7 @@ class Parser:
     def visit_dist_unit(self, node, (p, name, version, s)):
         return DistUnit(name, version)
 
-    @g.rule(r'version = ~"[0-9a-zA-Z]+(\.[0-9a-zA-Z])+"')
+    @g.rule(r'version = ~"[0-9a-zA-Z]+(\.[0-9a-zA-Z]+)+"')
     def visit_version(self, node, children):
         return node.text
 

--- a/quarkc/test/test_emit.py
+++ b/quarkc/test/test_emit.py
@@ -16,7 +16,7 @@ import os, pytest, shutil, subprocess, filecmp, difflib
 from quarkc.backend import Java, Python, JavaScript, Ruby
 from quarkc.compiler import Compiler, compile
 from quarkc.helpers import namever
-from .util import maybe_xfail, assert_file, filter_builtin
+from .util import maybe_xfail, filter_builtin
 
 backends = (Java, Python, JavaScript, Ruby)
 
@@ -55,10 +55,9 @@ def check_diff(output_root, expected_root, diff):
     assert not diff.left_only, diff.left_only
     assert not diff.right_only, diff.right_only
     for name in diff.diff_files:
-        with open(os.path.join(expected_root, name), "r") as expected_file:
-            assert_file(os.path.join(output_root, name), expected_file.read())
+        assert (filter_builtin(open(os.path.join(output_root, name)).read()) ==
+                filter_builtin(open(os.path.join(expected_root, name)).read()))
     for common_dirname, common_sub_diff in diff.subdirs.items():
-        print common_dirname
         check_diff(os.path.join(output_root, common_dirname),
                    os.path.join(expected_root, common_dirname),
                    common_sub_diff)

--- a/quarkc/test/util.py
+++ b/quarkc/test/util.py
@@ -34,8 +34,8 @@ def filter_builtin(content):
     result = []
     skipping = False
     for line in lines:
-        # Generate packaging hardcodes version 0.0.1 since we have different
-        # versions of Quark stdlib on each release:
+        # Checked-in test comparison packaging hardcodes version 0.0.1 since we
+        # have different versions of Quark stdlib on each release:
         quark_dependency = (('"quark": "0.0.1"' in line) or
                             ('"quark": "{}"'.format(_metadata.__version__) in line) or
                             ("spec.add_runtime_dependency 'quark'" in line) or

--- a/release
+++ b/release
@@ -143,16 +143,20 @@ def substitute(line, vars):
 
 def update_python(name, **kwargs):
     """Update a python file with supplied overrides."""
+    return update_file(name, lambda line: substitute(line, kwargs))
+
+def update_file(name, transform):
+    """Update a file by passing each line through a transform function."""
     lines = []
     orig_lines = []
     with open(name, "r") as fd:
         for line in fd:
             orig_lines.append(line)
-            lines.append(substitute(line, kwargs))
+            lines.append(transform(line))
     updated = "".join(lines)
     original = "".join(orig_lines)
     if updated != original:
-        print "Updating python %s: %s" % (name, kwargs)
+        print("Updating file %s: %s" % (name, set(lines) - set(orig_lines)))
         if __dry__: return True
         with open(name, "w") as fd:
             fd.write(updated)
@@ -182,6 +186,15 @@ def quark_version(version, doc_version, dev):
     for fname in ("quarkc/_metadata.py", "docs/conf.py"):
         if update_python(base(fname), **subs):
             updated.append(fname)
+
+    # Update quark stdlib package version:
+    def update_quark(line):
+        if line.startswith("package quark "):
+            return "package quark {};\n".format(version)
+        else:
+            return line
+    update_file(base("quarkc/lib/quark.q"), update_quark)
+    updated.append("quarkc/lib/quark.q")
 
     return title, updated
 


### PR DESCRIPTION
The Quark release version is used. This should make it easier for someone with their own internal package repo (PyPI, maven, gems, etc.) to host multiple versions of the Quark standard library.